### PR TITLE
Add first implementation of Somfy OAuth

### DIFF
--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import urllib.parse
 from json import JSONDecodeError
 from types import TracebackType
@@ -56,6 +57,7 @@ from pyoverkiz.models import (
     State,
 )
 
+_LOGGER = logging.getLogger(__name__)
 JSON = Union[Dict[str, Any], List[Dict[str, Any]]]
 
 
@@ -139,6 +141,7 @@ class OverkizClient:
         # Somfy TaHoma authentication using access_token
         if self.server == SUPPORTED_SERVERS["somfy_europe"]:
             access_token = await self.somfy_tahoma_login()
+            _LOGGER.debug("Using Somfy OAuth login")
             payload = {"accessToken": access_token}
 
         # CozyTouch authentication using jwt

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import urllib.parse
 from json import JSONDecodeError
 from types import TracebackType
@@ -57,7 +56,6 @@ from pyoverkiz.models import (
     State,
 )
 
-_LOGGER = logging.getLogger(__name__)
 JSON = Union[Dict[str, Any], List[Dict[str, Any]]]
 
 
@@ -141,7 +139,6 @@ class OverkizClient:
         # Somfy TaHoma authentication using access_token
         if self.server == SUPPORTED_SERVERS["somfy_europe"]:
             access_token = await self.somfy_tahoma_login()
-            _LOGGER.debug("Using Somfy OAuth login")
             payload = {"accessToken": access_token}
 
         # CozyTouch authentication using jwt

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -10,10 +10,6 @@ import backoff
 import humps
 from aiohttp import ClientResponse, ClientSession, ServerDisconnectedError
 
-from pyoverkiz.clients.atlantic_cozytouch_client import AtlanticCozytouchClient
-from pyoverkiz.clients.nexity_client import NexityClient
-from pyoverkiz.clients.simple_client import SimpleClient
-from pyoverkiz.clients.somfy_client import SomfyEuropeClient
 from pyoverkiz.exceptions import (
     BadCredentialsException,
     InvalidCommandException,
@@ -63,10 +59,6 @@ class OverkizClient:
     gateways: list[Gateway]
     event_listener_id: str | None
     session: ClientSession
-
-    @staticmethod
-    def get_client(server: OverkizServer) -> OverkizClient:
-        return CLIENTS.get(server, SimpleClient)
 
     def __init__(
         self,

--- a/pyoverkiz/clients/atlantic_cozytouch_client.py
+++ b/pyoverkiz/clients/atlantic_cozytouch_client.py
@@ -1,0 +1,77 @@
+from aiohttp import FormData
+from pyoverkiz.client import OverkizClient
+from pyoverkiz.const import COZYTOUCH_ATLANTIC_API, COZYTOUCH_CLIENT_ID
+from pyoverkiz.exceptions import BadCredentialsException
+
+
+class AtlanticCozytouchClient(OverkizClient):
+    async def login(
+        self,
+        register_event_listener: bool | None = True,
+    ) -> bool:
+        """
+        Authenticate and create an API session allowing access to the other operations.
+        Caller must provide one of [userId+userPassword, userId+ssoToken, accessToken, jwt]
+        """
+
+        jwt = await self.cozytouch_login()
+        payload = {"jwt": jwt}
+        response = await self.__post("login", data=payload)
+
+        if response.get("success"):
+            if register_event_listener:
+                await self.register_event_listener()
+            return True
+
+        return False
+
+    async def cozytouch_login(self) -> str:
+        """
+        Authenticate via CozyTouch identity and acquire JWT token.
+        """
+        # Request access token
+        async with self.session.post(
+            f"{COZYTOUCH_ATLANTIC_API}/token",
+            data=FormData(
+                {
+                    "grant_type": "password",
+                    "username": self.username,
+                    "password": self.password,
+                }
+            ),
+            headers={
+                "Authorization": f"Basic {COZYTOUCH_CLIENT_ID}",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+        ) as response:
+            token = await response.json()
+
+            # {'error': 'invalid_grant',
+            # 'error_description': 'Provided Authorization Grant is invalid.'}
+            if "error" in token and token["error"] == "invalid_grant":
+                raise CozyTouchBadCredentialsException(token["error_description"])
+
+            if "token_type" not in token:
+                raise CozyTouchServiceException("No CozyTouch token provided.")
+
+        # Request JWT
+        async with self.session.get(
+            f"{COZYTOUCH_ATLANTIC_API}/gacoma/gacomawcfservice/accounts/jwt",
+            headers={"Authorization": f"Bearer {token['access_token']}"},
+        ) as response:
+            jwt = await response.text()
+
+            if not jwt:
+                raise CozyTouchServiceException("No JWT token provided.")
+
+            jwt = jwt.strip('"')  # Remove surrounding quotes
+
+            return jwt
+
+
+class CozyTouchBadCredentialsException(BadCredentialsException):
+    pass
+
+
+class CozyTouchServiceException(Exception):
+    pass

--- a/pyoverkiz/clients/atlantic_cozytouch_client.py
+++ b/pyoverkiz/clients/atlantic_cozytouch_client.py
@@ -1,4 +1,5 @@
 from aiohttp import FormData
+
 from pyoverkiz.client import OverkizClient
 from pyoverkiz.const import COZYTOUCH_ATLANTIC_API, COZYTOUCH_CLIENT_ID
 from pyoverkiz.exceptions import BadCredentialsException

--- a/pyoverkiz/clients/nexity_client.py
+++ b/pyoverkiz/clients/nexity_client.py
@@ -1,0 +1,82 @@
+import asyncio
+from pyoverkiz.client import OverkizClient
+import boto3
+from botocore.config import Config
+from warrant_lite import WarrantLite
+
+from pyoverkiz.const import (
+    NEXITY_API,
+    NEXITY_COGNITO_CLIENT_ID,
+    NEXITY_COGNITO_REGION,
+    NEXITY_COGNITO_USER_POOL,
+)
+from pyoverkiz.exceptions import BadCredentialsException
+
+
+class NexityClient(OverkizClient):
+    async def login(
+        self,
+        register_event_listener: bool | None = True,
+    ) -> bool:
+        """
+        Authenticate and create an API session allowing access to the other operations.
+        Caller must provide one of [userId+userPassword, userId+ssoToken, accessToken, jwt]
+        """
+
+        sso_token = await self.nexity_login()
+        user_id = self.username.replace("@", "_-_")  # Replace @ for _-_
+        payload = {"ssoToken": sso_token, "userId": user_id}
+        response = await self.__post("login", data=payload)
+
+        if response.get("success"):
+            if register_event_listener:
+                await self.register_event_listener()
+            return True
+
+        return False
+
+    async def nexity_login(self) -> str:
+        """
+        Authenticate via Nexity identity and acquire SSO token.
+        """
+        loop = asyncio.get_event_loop()
+
+        # Request access token
+        client = boto3.client(
+            "cognito-idp", config=Config(region_name=NEXITY_COGNITO_REGION)
+        )
+        aws = WarrantLite(
+            username=self.username,
+            password=self.password,
+            pool_id=NEXITY_COGNITO_USER_POOL,
+            client_id=NEXITY_COGNITO_CLIENT_ID,
+            client=client,
+        )
+
+        try:
+            tokens = await loop.run_in_executor(None, aws.authenticate_user)
+        except Exception as error:
+            raise NexityBadCredentialsException() from error
+
+        id_token = tokens["AuthenticationResult"]["IdToken"]
+
+        async with self.session.get(
+            f"{NEXITY_API}/deploy/api/v1/domotic/token",
+            headers={
+                "Authorization": id_token,
+            },
+        ) as response:
+            token = await response.json()
+
+            if "token" not in token:
+                raise NexityServiceException("No Nexity SSO token provided.")
+
+            return cast(str, token["token"])
+
+
+class NexityBadCredentialsException(BadCredentialsException):
+    pass
+
+
+class NexityServiceException(Exception):
+    pass

--- a/pyoverkiz/clients/nexity_client.py
+++ b/pyoverkiz/clients/nexity_client.py
@@ -1,9 +1,11 @@
 import asyncio
-from pyoverkiz.client import OverkizClient
+from typing import cast
+
 import boto3
 from botocore.config import Config
 from warrant_lite import WarrantLite
 
+from pyoverkiz.client import OverkizClient
 from pyoverkiz.const import (
     NEXITY_API,
     NEXITY_COGNITO_CLIENT_ID,

--- a/pyoverkiz/clients/simple_client.py
+++ b/pyoverkiz/clients/simple_client.py
@@ -1,0 +1,22 @@
+from pyoverkiz.client import OverkizClient
+
+
+class SimpleClient(OverkizClient):
+    async def login(
+        self,
+        register_event_listener: bool | None = True,
+    ) -> bool:
+        """
+        Authenticate and create an API session allowing access to the other operations.
+        Caller must provide one of [userId+userPassword, userId+ssoToken, accessToken, jwt]
+        """
+
+        payload = {"userId": self.username, "userPassword": self.password}
+        response = await self.__post("login", data=payload)
+
+        if response.get("success"):
+            if register_event_listener:
+                await self.register_event_listener()
+            return True
+
+        return False

--- a/pyoverkiz/clients/somfy_client.py
+++ b/pyoverkiz/clients/somfy_client.py
@@ -1,11 +1,8 @@
 from aiohttp import FormData
+
 from pyoverkiz.client import OverkizClient
 from pyoverkiz.const import SOMFY_API, SOMFY_CLIENT_ID, SOMFY_CLIENT_SECRET
-from pyoverkiz.exceptions import (
-    BadCredentialsException,
-    SomfyBadCredentialsException,
-    SomfyServiceException,
-)
+from pyoverkiz.exceptions import BadCredentialsException
 
 
 class SomfyEuropeClient(OverkizClient):

--- a/pyoverkiz/clients/somfy_client.py
+++ b/pyoverkiz/clients/somfy_client.py
@@ -1,0 +1,68 @@
+from aiohttp import FormData
+from pyoverkiz.client import OverkizClient
+from pyoverkiz.const import SOMFY_API, SOMFY_CLIENT_ID, SOMFY_CLIENT_SECRET
+from pyoverkiz.exceptions import (
+    BadCredentialsException,
+    SomfyBadCredentialsException,
+    SomfyServiceException,
+)
+
+
+class SomfyEuropeClient(OverkizClient):
+    async def login(
+        self,
+        register_event_listener: bool | None = True,
+    ) -> bool:
+        """
+        Authenticate and create an API session allowing access to the other operations.
+        Caller must provide one of [userId+userPassword, userId+ssoToken, accessToken, jwt]
+        """
+
+        access_token = await self.somfy_tahoma_login()
+        payload = {"accessToken": access_token}
+        response = await self.__post("login", data=payload)
+
+        if response.get("success"):
+            if register_event_listener:
+                await self.register_event_listener()
+            return True
+
+        return False
+
+    async def somfy_tahoma_login(self) -> str:
+        """
+        Authenticate via Somfy identity and acquire access_token.
+        """
+        # Request access token
+        async with self.session.post(
+            f"{SOMFY_API}/oauth/oauth/v2/token",
+            data=FormData(
+                {
+                    "grant_type": "password",
+                    "username": self.username,
+                    "password": self.password,
+                    "client_id": SOMFY_CLIENT_ID,
+                    "client_secret": SOMFY_CLIENT_SECRET,
+                }
+            ),
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+        ) as response:
+            token = await response.json()
+            # { "message": "error.invalid.grant", "data": [], "uid": "xxx" }
+            if "message" in token and token["message"] == "error.invalid.grant":
+                raise SomfyBadCredentialsException(token["message"])
+
+            if "access_token" not in token:
+                raise SomfyServiceException("No Somfy access token provided.")
+
+            return str(token["access_token"])
+
+
+class SomfyBadCredentialsException(BadCredentialsException):
+    pass
+
+
+class SomfyServiceException(Exception):
+    pass

--- a/pyoverkiz/const.py
+++ b/pyoverkiz/const.py
@@ -12,6 +12,10 @@ NEXITY_COGNITO_CLIENT_ID = "3mca95jd5ase5lfde65rerovok"
 NEXITY_COGNITO_USER_POOL = "eu-west-1_wj277ucoI"
 NEXITY_COGNITO_REGION = "eu-west-1"
 
+SOMFY_API = "https://accounts.somfy.com"
+SOMFY_CLIENT_ID = "0d8e920c-1478-11e7-a377-02dd59bd3041_1ewvaqmclfogo4kcsoo0c8k4kso884owg08sg8c40sk4go4ksg"
+SOMFY_CLIENT_SECRET = "12k73w1n540g8o4cokg0cw84cog840k84cwggscwg884004kgk"
+
 SUPPORTED_SERVERS: dict[str, OverkizServer] = {
     "atlantic_cozytouch": OverkizServer(
         name="Atlantic Cozytouch",

--- a/pyoverkiz/const.py
+++ b/pyoverkiz/const.py
@@ -1,4 +1,8 @@
 from __future__ import annotations
+from pyoverkiz.client import OverkizClient
+from pyoverkiz.clients.atlantic_cozytouch_client import AtlanticCozytouchClient
+from pyoverkiz.clients.nexity_client import NexityClient
+from pyoverkiz.clients.somfy_client import SomfyEuropeClient
 
 from pyoverkiz.models import OverkizServer
 
@@ -71,4 +75,10 @@ SUPPORTED_SERVERS: dict[str, OverkizServer] = {
         manufacturer="Somfy",
         configuration_url=None,
     ),
+}
+
+CLIENTS: dict[str, OverkizClient] = {
+    "somfy_europe": SomfyEuropeClient,
+    "atlantic_cozytouch": AtlanticCozytouchClient,
+    "nexity": NexityClient,
 }

--- a/pyoverkiz/const.py
+++ b/pyoverkiz/const.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
-from pyoverkiz.client import OverkizClient
+
 from pyoverkiz.clients.atlantic_cozytouch_client import AtlanticCozytouchClient
 from pyoverkiz.clients.nexity_client import NexityClient
 from pyoverkiz.clients.somfy_client import SomfyEuropeClient
-
 from pyoverkiz.models import OverkizServer
 
 COZYTOUCH_ATLANTIC_API = "https://api.groupe-atlantic.com"
@@ -26,6 +25,7 @@ SUPPORTED_SERVERS: dict[str, OverkizServer] = {
         endpoint="https://ha110-1.overkiz.com/enduser-mobile-web/enduserAPI/",
         manufacturer="Atlantic",
         configuration_url=None,
+        client_class=AtlanticCozytouchClient,
     ),
     "hi_kumo_asia": OverkizServer(
         name="Hitachi Hi Kumo (Asia)",
@@ -50,6 +50,7 @@ SUPPORTED_SERVERS: dict[str, OverkizServer] = {
         endpoint="https://ha106-1.overkiz.com/enduser-mobile-web/enduserAPI/",
         manufacturer="Nexity",
         configuration_url=None,
+        client_class=NexityClient,
     ),
     "rexel": OverkizServer(
         name="Rexel Energeasy Connect",
@@ -62,6 +63,7 @@ SUPPORTED_SERVERS: dict[str, OverkizServer] = {
         endpoint="https://tahomalink.com/enduser-mobile-web/enduserAPI/",
         manufacturer="Somfy",
         configuration_url="https://www.tahomalink.com",
+        client_class=SomfyEuropeClient,
     ),
     "somfy_america": OverkizServer(
         name="Somfy (North America)",
@@ -75,10 +77,4 @@ SUPPORTED_SERVERS: dict[str, OverkizServer] = {
         manufacturer="Somfy",
         configuration_url=None,
     ),
-}
-
-CLIENTS: dict[str, OverkizClient] = {
-    "somfy_europe": SomfyEuropeClient,
-    "atlantic_cozytouch": AtlanticCozytouchClient,
-    "nexity": NexityClient,
 }

--- a/pyoverkiz/exceptions.py
+++ b/pyoverkiz/exceptions.py
@@ -46,3 +46,12 @@ class CozyTouchBadCredentialsException(BadCredentialsException):
 
 class CozyTouchServiceException(Exception):
     pass
+
+
+# Somfy
+class SomfyBadCredentialsException(BadCredentialsException):
+    pass
+
+
+class SomfyServiceException(Exception):
+    pass

--- a/pyoverkiz/exceptions.py
+++ b/pyoverkiz/exceptions.py
@@ -28,30 +28,3 @@ class InvalidEventListenerIdException(Exception):
 
 class NoRegisteredEventListenerException(Exception):
     pass
-
-
-# Nexity
-class NexityBadCredentialsException(BadCredentialsException):
-    pass
-
-
-class NexityServiceException(Exception):
-    pass
-
-
-# CozyTouch
-class CozyTouchBadCredentialsException(BadCredentialsException):
-    pass
-
-
-class CozyTouchServiceException(Exception):
-    pass
-
-
-# Somfy
-class SomfyBadCredentialsException(BadCredentialsException):
-    pass
-
-
-class SomfyServiceException(Exception):
-    pass

--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Iterator
+from typing import Any, Iterator, TypeVar
 
 from attr import define, field
 
+from pyoverkiz.client import OverkizClient
+from pyoverkiz.clients.simple_client import SimpleClient
 from pyoverkiz.enums import (
     DataType,
     EventName,
@@ -695,6 +697,9 @@ class Zone:
         self.oid = oid
 
 
+T = TypeVar("T", bound="OverkizClient")
+
+
 @define(kw_only=True)
 class OverkizServer:
     """Class to describe an Overkiz server."""
@@ -703,3 +708,4 @@ class OverkizServer:
     endpoint: str
     manufacturer: str
     configuration_url: str | None
+    client_class: type[T] = SimpleClient

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,7 +6,6 @@ import aiohttp
 import pytest
 from pytest import fixture
 
-from pyoverkiz.client import OverkizClient
 from pyoverkiz.clients.simple_client import SimpleClient
 from pyoverkiz.const import SUPPORTED_SERVERS
 from pyoverkiz.enums import DataType

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,6 +7,7 @@ import pytest
 from pytest import fixture
 
 from pyoverkiz.client import OverkizClient
+from pyoverkiz.clients.simple_client import SimpleClient
 from pyoverkiz.const import SUPPORTED_SERVERS
 from pyoverkiz.enums import DataType
 
@@ -16,7 +17,7 @@ CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 class TestOverkizClient:
     @fixture
     def client(self):
-        return OverkizClient("username", "password", SUPPORTED_SERVERS["somfy_europe"])
+        return SimpleClient("username", "password", SUPPORTED_SERVERS["somfy_europe"])
 
     @pytest.mark.asyncio
     async def test_get_devices_basic(self, client):


### PR DESCRIPTION
This currently works but will relogin via backoff every hour (see expires). Eventually best would be to see if we can improve the Somfy, Cozytouch and Nexity login code since none of them handle the tokens currently.

```json
{
	"access_token": "",
	"expires_in": 3600,
	"token_type": "bearer",
	"scope": "user.basic api.full oa.site oa.subscription oa.user oa.device oa.devicedefinition level.0",
	"refresh_token": ""
}
```