### PR TITLE
Obfuscate label in logging

### DIFF
--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -138,7 +138,7 @@ class Device:
     attributes: States
     available: bool
     enabled: bool
-    label: str = field(repr=obfuscate_string, default=None)
+    label: str = field(repr=obfuscate_string)
     device_url: str = field(repr=obfuscate_id)
     controllable_name: str
     definition: Definition
@@ -447,7 +447,7 @@ class Execution:
 
 @define(init=False, kw_only=True)
 class Scenario:
-    label: str = field(repr=obfuscate_string, default=None)
+    label: str = field(repr=obfuscate_string)
     oid: str = field(repr=obfuscate_id)
 
     def __init__(self, label: str, oid: str, **_: Any):

--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -138,7 +138,7 @@ class Device:
     attributes: States
     available: bool
     enabled: bool
-    label: str
+    label: str = field(repr=obfuscate_string, default=None)
     device_url: str = field(repr=obfuscate_id)
     controllable_name: str
     definition: Definition
@@ -447,7 +447,7 @@ class Execution:
 
 @define(init=False, kw_only=True)
 class Scenario:
-    label: str
+    label: str = field(repr=obfuscate_string, default=None)
     oid: str = field(repr=obfuscate_id)
 
     def __init__(self, label: str, oid: str, **_: Any):


### PR DESCRIPTION
Label is used for the user friendly name as well, we do redact this in our diagnostic logging, but not in our debug logging yet.