### PR TITLE
Fix support for SIMU (LiveIn2) devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This package is written for the Home Assistant [ha-tahoma](https://github.com/iM
 - Hitachi Hi Kumo
 - Nexity Eugénie
 - Rexel Energeasy Connect
+- Simu (LiveIn2)
 - Somfy Connexoon IO
 - Somfy Connexoon RTS
 - Somfy TaHoma

--- a/pyoverkiz/const.py
+++ b/pyoverkiz/const.py
@@ -63,7 +63,7 @@ SUPPORTED_SERVERS: dict[str, OverkizServer] = {
         name="SIMU (LiveIn2)",
         endpoint="https://tahomalink.com/enduser-mobile-web/enduserAPI/",
         manufacturer="Somfy",
-        configuration_url="https://www.tahomalink.com",
+        configuration_url=None,
     ),
     "somfy_europe": OverkizServer(  # uses https://ha101-1.overkiz.com
         name="Somfy (Europe)",

--- a/pyoverkiz/const.py
+++ b/pyoverkiz/const.py
@@ -59,6 +59,12 @@ SUPPORTED_SERVERS: dict[str, OverkizServer] = {
         manufacturer="Rexel",
         configuration_url="https://utilisateur.energeasyconnect.com/user/#/zone/equipements",
     ),
+    "simu_livein2": OverkizServer(  # uses https://ha101-1.overkiz.com
+        name="SIMU (LiveIn2)",
+        endpoint="https://tahomalink.com/enduser-mobile-web/enduserAPI/",
+        manufacturer="Somfy",
+        configuration_url="https://www.tahomalink.com",
+    ),
     "somfy_europe": OverkizServer(  # uses https://ha101-1.overkiz.com
         name="Somfy (Europe)",
         endpoint="https://tahomalink.com/enduser-mobile-web/enduserAPI/",


### PR DESCRIPTION
Added support for SIMU (LiveIn2) devices - uses Somfy endpoint, but with old style authentication.