### PR TITLE
Change tahomalink.com to direct server URL (ha101-1.overkiz.com)

### DIFF
--- a/pyoverkiz/const.py
+++ b/pyoverkiz/const.py
@@ -59,15 +59,15 @@ SUPPORTED_SERVERS: dict[str, OverkizServer] = {
         manufacturer="Rexel",
         configuration_url="https://utilisateur.energeasyconnect.com/user/#/zone/equipements",
     ),
-    "simu_livein2": OverkizServer(  # uses https://ha101-1.overkiz.com
+    "simu_livein2": OverkizServer(  # alias of https://tahomalink.com
         name="SIMU (LiveIn2)",
-        endpoint="https://tahomalink.com/enduser-mobile-web/enduserAPI/",
+        endpoint="https://ha101-1.overkiz.com/enduser-mobile-web/enduserAPI/",
         manufacturer="Somfy",
         configuration_url=None,
     ),
-    "somfy_europe": OverkizServer(  # uses https://ha101-1.overkiz.com
+    "somfy_europe": OverkizServer(  # alias of https://tahomalink.com
         name="Somfy (Europe)",
-        endpoint="https://tahomalink.com/enduser-mobile-web/enduserAPI/",
+        endpoint="https://ha101-1.overkiz.com/enduser-mobile-web/enduserAPI/",
         manufacturer="Somfy",
         configuration_url="https://www.tahomalink.com",
     ),


### PR DESCRIPTION
Fixes #538 
Fixes tahomalink.com certificate expiring every year...