### PR TITLE
Update backoff to 2.2.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -81,11 +81,11 @@ tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy 
 
 [[package]]
 name = "backoff"
-version = "1.11.1"
+version = "2.2.1"
 description = "Function decoration for backoff and retry"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.7,<4.0"
 
 [[package]]
 name = "black"
@@ -849,7 +849,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "38bc7fe3d1722497140d44fed585f59865f53164ac5d85163c9814afdab4fe16"
+content-hash = "e777c09ba7ee40c40d09ea285adfa3ad578991a8cf1ae27ab9d854187bd85f86"
 
 [metadata.files]
 aiohttp = [
@@ -962,8 +962,8 @@ attrs = [
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
 ]
 backoff = [
-    {file = "backoff-1.11.1-py2.py3-none-any.whl", hash = "sha256:61928f8fa48d52e4faa81875eecf308eccfb1016b018bb6bd21e05b5d90a96c5"},
-    {file = "backoff-1.11.1.tar.gz", hash = "sha256:ccb962a2378418c667b3c979b504fdeb7d9e0d29c0579e3b13b86467177728cb"},
+    {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
+    {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
 ]
 black = [
     {file = "black-22.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ce957f1d6b78a8a231b18e0dd2d94a33d2ba738cd88a7fe64f53f659eea49fdd"},

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import urllib.parse
+from collections.abc import Mapping
 from json import JSONDecodeError
 from types import TracebackType
 from typing import Any, cast
@@ -70,11 +71,11 @@ from pyoverkiz.obfuscate import obfuscate_sensitive_data
 from pyoverkiz.types import JSON
 
 
-async def relogin(invocation: dict[str, Any]) -> None:
+async def relogin(invocation: Mapping[str, Any]) -> None:
     await invocation["args"][0].login()
 
 
-async def refresh_listener(invocation: dict[str, Any]) -> None:
+async def refresh_listener(invocation: Mapping[str, Any]) -> None:
     await invocation["args"][0].register_event_listener()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
 aiohttp = "^3.6.1"
-pyhumps = "^3.0.2"
-backoff = "^1.10.0"
+pyhumps = "^3.0.2,!=3.7.3"
+backoff = ">=1.10.0,<3.0"
 attrs = ">=21.2,<23.0"
 boto3 = "^1.18.59"
 warrant-lite = "^1.0.4"


### PR DESCRIPTION
Exclude `pyhumps` version `3.7.3` due to invalid `__all__`. See https://github.com/nficano/humps/pull/281

Replaces: #510 and #583