### PR TITLE
Add base_device_url and corresponding tests on Device model

### DIFF
--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -144,6 +144,7 @@ class Device:
     enabled: bool
     label: str = field(repr=obfuscate_string)
     device_url: str = field(repr=obfuscate_id)
+    base_device_url: str = field(repr=obfuscate_id)
     gateway_id: str = field(repr=obfuscate_id)
     device_address: str = field(repr=obfuscate_id)
     subsystem_id: int | None = None
@@ -200,6 +201,10 @@ class Device:
             self.protocol = Protocol(match.group("protocol"))
             self.gateway_id = match.group("gatewayId")
             self.device_address = match.group("deviceAddress")
+
+            self.base_device_url = (
+                self.protocol + "://" + self.gateway_id + "/" + self.device_address
+            )
 
             if match.group("subsystemId"):
                 self.subsystem_id = int(match.group("subsystemId"))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -151,6 +151,7 @@ class TestOverkizClient:
                 assert device.gateway_id
                 assert device.device_address
                 assert device.protocol
+                assert device.base_device_url
 
 
 class MockResponse:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -65,9 +65,10 @@ STATE = "core:NameState"
 
 class TestDevice:
     @pytest.mark.parametrize(
-        "device_url, protocol, gateway_id, device_address, subsystem_id, is_sub_device",
+        "device_url, base_device_url, protocol, gateway_id, device_address, subsystem_id, is_sub_device",
         [
             (
+                "io://1234-5678-9012/10077486",
                 "io://1234-5678-9012/10077486",
                 Protocol.IO,
                 "1234-5678-9012",
@@ -77,6 +78,7 @@ class TestDevice:
             ),
             (
                 "io://1234-5678-9012/10077486#8",
+                "io://1234-5678-9012/10077486",
                 Protocol.IO,
                 "1234-5678-9012",
                 "10077486",
@@ -84,6 +86,7 @@ class TestDevice:
                 True,
             ),
             (
+                "hue://1234-1234-4411/001788676dde/lights/10",
                 "hue://1234-1234-4411/001788676dde/lights/10",
                 Protocol.HUE,
                 "1234-1234-4411",
@@ -93,6 +96,7 @@ class TestDevice:
             ),
             (
                 "hue://1234-1234-4411/001788676dde/lights/10#5",
+                "hue://1234-1234-4411/001788676dde/lights/10",
                 Protocol.HUE,
                 "1234-1234-4411",
                 "001788676dde/lights/10",
@@ -100,6 +104,7 @@ class TestDevice:
                 True,
             ),
             (
+                "upnpcontrol://1234-1234-4411/uuid:RINCON_000E586B571601400",
                 "upnpcontrol://1234-1234-4411/uuid:RINCON_000E586B571601400",
                 Protocol.UPNP_CONTROL,
                 "1234-1234-4411",
@@ -109,6 +114,7 @@ class TestDevice:
             ),
             (
                 "upnpcontrol://1234-1234-4411/uuid:RINCON_000E586B571601400#7",
+                "upnpcontrol://1234-1234-4411/uuid:RINCON_000E586B571601400",
                 Protocol.UPNP_CONTROL,
                 "1234-1234-4411",
                 "uuid:RINCON_000E586B571601400",
@@ -116,6 +122,7 @@ class TestDevice:
                 True,
             ),
             (
+                "zigbee://1234-1234-1234/9876/1",
                 "zigbee://1234-1234-1234/9876/1",
                 Protocol.ZIGBEE,
                 "1234-1234-1234",
@@ -125,6 +132,7 @@ class TestDevice:
             ),
             (
                 "zigbee://1234-1234-1234/9876/1#2",
+                "zigbee://1234-1234-1234/9876/1",
                 Protocol.ZIGBEE,
                 "1234-1234-1234",
                 "9876/1",
@@ -136,6 +144,7 @@ class TestDevice:
     def test_base_url_parsing(
         self,
         device_url: str,
+        base_device_url: str,
         protocol: Protocol,
         gateway_id: str,
         device_address: str,
@@ -149,6 +158,7 @@ class TestDevice:
         hump_device = humps.decamelize(test_device)
         device = Device(**hump_device)
 
+        assert device.base_device_url == base_device_url
         assert device.protocol == protocol
         assert device.gateway_id == gateway_id
         assert device.device_address == device_address


### PR DESCRIPTION
After starting the implementation on HA component, I figured out that we where missing the base_device_url.  
We could recreate it there, but I think it's better to have always available on the device info.