### PR TITLE
Add SET_SCHEDULING_TYPE command

### DIFF
--- a/pyoverkiz/enums/command.py
+++ b/pyoverkiz/enums/command.py
@@ -100,6 +100,7 @@ class OverkizCommand(str, Enum):
     SET_PASS_APC_OPERATING_MODE = "setPassAPCOperatingMode"
     SET_PEDESTRIAN_POSITION = "setPedestrianPosition"
     SET_RGB = "setRGB"
+    SET_SCHEDULING_TYPE = "setSchedulingType"
     SET_SECURED_POSITION_TEMPERATURE = "setSecuredPositionTemperature"
     SET_TARGET_ALARM_MODE = "setTargetAlarmMode"
     SET_TARGET_TEMPERATURE = "setTargetTemperature"


### PR DESCRIPTION
This will be used for https://github.com/home-assistant/core/pull/84010

The more I'm using pyoverkiz, the more I'm wondering: Why do we need to maintain a list of all commands here?  
This is pretty heavy to have to :  
1. MR here
2. Wait for release
3. Do the requirements update on HA

Essentially when, like this MR, it concerns only 1 command...