### PR TITLE
command: Add SET_CLOSURE_AND_ORIENTATION

### DIFF
--- a/pyoverkiz/enums/command.py
+++ b/pyoverkiz/enums/command.py
@@ -80,6 +80,7 @@ class OverkizCommand(StrEnum):
     SET_BOOST_ON_OFF_STATE = "setBoostOnOffState"
     SET_CLOSURE = "setClosure"
     SET_CLOSURE_AND_LINEAR_SPEED = "setClosureAndLinearSpeed"
+    SET_CLOSURE_AND_ORIENTATION = "setClosureAndOrientation"
     SET_COMFORT_HEATING_TARGET_TEMPERATURE = "setComfortHeatingTargetTemperature"
     SET_COMFORT_TARGET_DHW_TEMPERATURE = "setComfortTargetDHWTemperature"
     SET_COMFORT_TEMPERATURE = "setComfortTemperature"


### PR DESCRIPTION
Add SET_CLOSURE_AND_ORIENTATION to the command enum. This command is supported by Somfy J4 io Protect motors and allows to set the blind closure as well as the slide orientation in one command.

I would like to add support for this command to the home assistant overkiz integration in the future. But for now I'd already find it helpful if the command was available in the `python-overkiz-api`.

The main advantage for using this command (compared to individual commands) is that the slides will not change the orientation if the motor is already in the correct closure position. There's also no need to wait for the target position to be reached before modifying the orientation. It's also helpful for automating multiple motors, because it allows that in less commands overall.
