### PR TITLE
client: Add refresh_device_states

### DIFF
--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -533,6 +533,17 @@ class OverkizClient:
         """
         await self.__post("setup/devices/states/refresh")
 
+    @backoff.on_exception(
+        backoff.expo, NotAuthenticatedException, max_tries=2, on_backoff=relogin
+    )
+    async def refresh_device_states(self, deviceurl: str) -> None:
+        """
+        Ask the box to refresh all states of the given device for protocols supporting that operation
+        """
+        await self.__post(
+            f"setup/devices/{urllib.parse.quote_plus(deviceurl)}/states/refresh"
+        )
+
     @backoff.on_exception(backoff.expo, TooManyConcurrentRequestsException, max_tries=5)
     async def register_event_listener(self) -> str:
         """


### PR DESCRIPTION
`python-overkiz-api` already has a method to refresh all states of all devices. This method is used by the Somfy TaHoma web interface on login/start and it asks all devices to send their states to the gateway.

For some devices like the Somfy Dexxo io garage door motors, this call is essential because these motors do not always send their state updates automatically to the gateway and require a manual refresh. See my discussion with Somfy in https://github.com/Somfy-Developer/Somfy-TaHoma-Developer-Mode/issues/26#issuecomment-1598316333.

Now besides refreshing all states of all devices, the Somfy API also supports to refresh only the states of a specific device via `setup/devices/{device_url}/states/refresh`.

I'll also create a draft PR for `homeassistant/core` that shows how this method could be used to solve #167 (at least for garage doors and gates). But even independent of that, I believe it's a helpful addition to `python-overkiz-api`.

Screenshot of the Somfy API docs:
![grafik](https://github.com/iMicknl/python-overkiz-api/assets/1133994/ad069cfb-67f7-464b-8556-7411cdc0235c)
