### PR TITLE
command: Fix partial position command

### DIFF
--- a/pyoverkiz/enums/command.py
+++ b/pyoverkiz/enums/command.py
@@ -50,6 +50,7 @@ class OverkizCommand(StrEnum):
     OPEN = "open"
     OPEN_SLATS = "openSlats"
     PARTIAL = "partial"
+    PARTIAL_POSITION = "partialPosition"
     REFRESH_BOOST_MODE_DURATION = "refreshBoostModeDuration"
     REFRESH_COMFORT_HEATING_TARGET_TEMPERATURE = (
         "refreshComfortHeatingTargetTemperature"
@@ -111,7 +112,6 @@ class OverkizCommand(StrEnum):
     SET_MODE_TEMPERATURE = "setModeTemperature"
     SET_OPERATING_MODE = "setOperatingMode"
     SET_ORIENTATION = "setOrientation"
-    SET_PARTIAL_POSITION = "setPartialPosition"
     SET_PASS_APC_DHW_MODE = "setPassAPCDHWMode"
     SET_PASS_APC_HEATING_MODE = "setPassAPCHeatingMode"
     SET_PASS_APC_OPERATING_MODE = "setPassAPCOperatingMode"


### PR DESCRIPTION
Commit 4bbc5f8 introduced the `SET_PARTIAL_POSITION="setParitalPosition"` command. However, the command is really called "partialPosition".

---

Sorry, this slipped in - most likely because I was doing the corresponding change in the integration similar to the gate's `SET_PEDESTRIAN_POSITION` and got confused by that. In the pasted JSON in https://github.com/iMicknl/python-overkiz-api/pull/957 you can see that "partialPosition" is correct and not "setPartialPosition".