### PR TITLE
Improve email obfuscation for Nexity accounts

### DIFF
--- a/pyoverkiz/obfuscate.py
+++ b/pyoverkiz/obfuscate.py
@@ -14,7 +14,8 @@ def obfuscate_id(id: str | None) -> str:
 
 def obfuscate_email(email: str | None) -> str:
     """Mask email"""
-    return re.sub(r"(.).*@.*(.\..*)", r"\1****@****\2", str(email))
+    email = str(email).replace("_-_", "@")  # Replace @ for _-_ (Nexity)
+    return re.sub(r"(.).*@.*(.\..*)", r"\1****@****\2", email)
 
 
 def obfuscate_string(input: str) -> str:

--- a/tests/test_obfuscate.py
+++ b/tests/test_obfuscate.py
@@ -1,0 +1,18 @@
+import pytest
+
+from pyoverkiz.obfuscate import obfuscate_email
+
+LOCAL_HOST = "gateway-1234-5678-1243.local:8443"
+LOCAL_HOST_BY_IP = "192.168.1.105:8443"
+
+
+class TestObfucscate:
+    @pytest.mark.parametrize(
+        "email, obfuscated",
+        [
+            ("contact@somfy.com", "c****@****y.com"),
+            ("contact_-_nexity.com", "c****@****y.com"),
+        ],
+    )
+    def test_email_obfuscate(self, email: str, obfuscated: str):
+        assert obfuscate_email(email) == obfuscated


### PR DESCRIPTION
Nexity uses `_-_` instead of `@` for email addresses, and thus we didn't catch this correctly.