### PR TITLE
Add gateway ID for new Nexity rail din S box

### DIFF
--- a/pyoverkiz/enums/gateway.py
+++ b/pyoverkiz/enums/gateway.py
@@ -57,6 +57,7 @@ class GatewayType(IntEnum):
     SOMFY_CONNECTIVITY_KIT = 99
     COZYTOUCH_V2 = 105
     TAHOMA_RAIL_DIN_S = 108
+    NEXITY_RAIL_DIN_S = 109
 
     @classmethod
     def _missing_(cls, value):  # type: ignore


### PR DESCRIPTION
I just moved into a new appartment that has a Nexity/Somfy box in the electrical switchboard. It has an ID of **109** and looks just like the TaHoma Rail-DIN S, so I created a new entry in the `GatewayType` enum with the name **NEXITY_RAIL_DIN_S**.

Merging this pull request will prevent the following message from appearing the in logs of Home Assistant:
`Unsupported value 109 has been returned for <enum 'GatewayType'>`

Here is a picture of the box for reference: [https://i.imgur.com/BJmhLgm.jpg](https://i.imgur.com/BJmhLgm.jpg)