### PR TITLE
Add setDateTime command constant

### DIFF
--- a/pyoverkiz/enums/command.py
+++ b/pyoverkiz/enums/command.py
@@ -127,6 +127,7 @@ class OverkizCommand(StrEnum):
     SET_COOLING_ON_OFF = "setCoolingOnOffState"
     SET_COOLING_TARGET_TEMPERATURE = "setCoolingTargetTemperature"
     SET_CURRENT_OPERATING_MODE = "setCurrentOperatingMode"
+    SET_DATE_TIME = "setDateTime"
     SET_DEPLOYMENT = "setDeployment"
     SET_DEROGATED_TARGET_TEMPERATURE = "setDerogatedTargetTemperature"
     SET_DEROGATION = "setDerogation"


### PR DESCRIPTION
Adds setDateTime command for Atlantic DHW that sets the datetime for the device.
I have found that my device had the wrong date set on it, so all my experiments with setting away start date and away end date are inconsistent due to this.
I want to make sure that https://github.com/home-assistant/core/pull/121801 sets the correct current datetime on the device before setting away start date and end dates for the user.