### PR TITLE
Update Cozytouch server name to include whitelabeled brands (Thermor, Sauter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This package is mainly used by Home Assistant Core, to offer the Overkiz integra
 - Hitachi Hi Kumo
 - Nexity Eugénie
 - Rexel Energeasy Connect
+- Sauter Cozytouch
 - Simu (LiveIn2)
 - Somfy Connexoon IO
 - Somfy Connexoon RTS

--- a/pyoverkiz/const.py
+++ b/pyoverkiz/const.py
@@ -27,7 +27,7 @@ SERVERS_WITH_LOCAL_API = [
 
 SUPPORTED_SERVERS: dict[str, OverkizServer] = {
     Server.ATLANTIC_COZYTOUCH: OverkizServer(
-        name="Atlantic Cozytouch",
+        name="Cozytouch (Atlantic, Thermor, Sauter)",
         endpoint="https://ha110-1.overkiz.com/enduser-mobile-web/enduserAPI/",
         manufacturer="Atlantic",
         configuration_url=None,


### PR DESCRIPTION
Thermor Cozytouch and Sauter Cozytouch are simply whitelabeled Atlantic Cozytouch bridges and apps, using the same servers and accounts.

To ease usage for people buying those whitelabaled products, changing server name to "Cozytouch (Atlantic, Thermor, Sauter)" instead of "Atlantic Cozytouch".
It will be easier to find and choose the right server if you bought a Cozytouch bridge from Thermor or Sauter.