### PR TITLE
add refreshAwayModeDuration OverkizCommand

### DIFF
--- a/pyoverkiz/enums/command.py
+++ b/pyoverkiz/enums/command.py
@@ -55,6 +55,7 @@ class OverkizCommand(StrEnum):
     PARTIAL = "partial"
     PARTIAL_POSITION = "partialPosition"
     REFRESH_ABSENCE_SCHEDULING_AVAILABILITY = "refreshAbsenceSchedulingAvailability"
+    REFRESH_AWAY_MODE_DURATION = "refreshAwayModeDuration"
     REFRESH_BOOST_MODE_DURATION = "refreshBoostModeDuration"
     REFRESH_COMFORT_COOLING_TARGET_TEMPERATURE = (
         "refreshComfortCoolingTargetTemperature"


### PR DESCRIPTION
Adds `refreshAwayModeDuration` OverkizCommand for AtlanticDomesticHotWaterProductionV2IOComponent, which is Atlantic Explorer V4.
This change is needed for the newly created PR from https://github.com/home-assistant/core/compare/dev...ALERTua:fork_ha_core:AtlanticDomesticHotWaterProductionV2_CV4E_IOComponent