### PR TITLE
add antifreeze OverkizCommand

### DIFF
--- a/pyoverkiz/enums/command.py
+++ b/pyoverkiz/enums/command.py
@@ -20,6 +20,7 @@ class OverkizCommand(StrEnum):
     ALARM_PARTIAL_1 = "alarmPartial1"
     ALARM_PARTIAL_2 = "alarmPartial2"
     ALARM_ZONE_ON = "alarmZoneOn"
+    ANTIFREEZE = "antifreeze"
     ARM = "arm"
     ARM_PARTIAL_DAY = "armPartialDay"
     ARM_PARTIAL_NIGHT = "armPartialNight"


### PR DESCRIPTION
Adds `antifreeze` OverkizCommand for AtlanticDomesticHotWaterProductionV2IOComponent, which is Atlantic Explorer V4.
This change is needed for the newly created PR from https://github.com/home-assistant/core/compare/dev...ALERTua:fork_ha_core:AtlanticDomesticHotWaterProductionV2_CV4E_IOComponent