### PR TITLE
add program OverkizCommandParam

### DIFF
--- a/pyoverkiz/enums/command.py
+++ b/pyoverkiz/enums/command.py
@@ -54,7 +54,6 @@ class OverkizCommand(StrEnum):
     OPEN_SLATS = "openSlats"
     PARTIAL = "partial"
     PARTIAL_POSITION = "partialPosition"
-    PROGRAM = "program"
     REFRESH_ABSENCE_SCHEDULING_AVAILABILITY = "refreshAbsenceSchedulingAvailability"
     REFRESH_BOOST_MODE_DURATION = "refreshBoostModeDuration"
     REFRESH_COMFORT_COOLING_TARGET_TEMPERATURE = (
@@ -304,6 +303,7 @@ class OverkizCommandParam(StrEnum):
     PERMANENT_HEATING = "permanentHeating"
     PERSON_INSIDE = "personInside"
     PROG = "prog"
+    PROGRAM = "program"
     RELAUNCH = "relaunch"
     RESET = "reset"
     SAAC = "SAAC"

--- a/pyoverkiz/enums/command.py
+++ b/pyoverkiz/enums/command.py
@@ -54,6 +54,7 @@ class OverkizCommand(StrEnum):
     OPEN_SLATS = "openSlats"
     PARTIAL = "partial"
     PARTIAL_POSITION = "partialPosition"
+    PROGRAM = "program"
     REFRESH_ABSENCE_SCHEDULING_AVAILABILITY = "refreshAbsenceSchedulingAvailability"
     REFRESH_BOOST_MODE_DURATION = "refreshBoostModeDuration"
     REFRESH_COMFORT_COOLING_TARGET_TEMPERATURE = (


### PR DESCRIPTION
Adds `program` OverkizCommandParam for AtlanticDomesticHotWaterProductionV2IOComponent, which is Atlantic Explorer V4.
This change is needed for the newly created PR https://github.com/home-assistant/core/pull/139524