### PR TITLE
Add always OverkizCommandParam

### DIFF
--- a/pyoverkiz/enums/command.py
+++ b/pyoverkiz/enums/command.py
@@ -202,6 +202,7 @@ class OverkizCommandParam(StrEnum):
     ACTIVE = "active"
     ADJUSTMENT = "adjustment"
     ANTIFREEZE = "antifreeze"
+    ALWAYS = "always"
     ARMED = "armed"
     ARMED_DAY = "armedDay"
     ARMED_NIGHT = "armedNight"


### PR DESCRIPTION
sorry, yesterday I forgot to add one enum :/
Adds `always` OverkizCommandParam for AtlanticDomesticHotWaterProductionV2IOComponent, which is Atlantic Explorer V4.
This change is needed for the newly created PR https://github.com/home-assistant/core/pull/139524