### PR TITLE
Add CORE_BATTERY_DISCRETE_LEVEL to OverkizState enum

### DIFF
--- a/pyoverkiz/enums/state.py
+++ b/pyoverkiz/enums/state.py
@@ -49,6 +49,7 @@ class OverkizState(StrEnum):
     CORE_AVAILABILITY = "core:AvailabilityState"
     CORE_BATTERY = "core:BatteryState"
     CORE_BATTERY_LEVEL = "core:BatteryLevelState"
+    CORE_BATTERY_DISCRETE_LEVEL = "core:BatteryDiscreteLevelState"
     CORE_BLUE_COLOR_INTENSITY = "core:BlueColorIntensityState"
     CORE_BOOST_ELECTRIC_POWER_CONSUMPTION = "core:BoostElectricPowerConsumptionState"
     CORE_BOOST_END_DATE = "core:BoostEndDateState"


### PR DESCRIPTION
This pull request includes an addition to the `OverkizState` class in the `pyoverkiz/enums/state.py` file. The change adds a new state for battery discrete level.

* [`pyoverkiz/enums/state.py`](diffhunk://#diff-a1a0a84530d8160c1aebf89595156a89165c214b11802a516be01cc8f900327bR52): Added `CORE_BATTERY_DISCRETE_LEVEL` to the `OverkizState` class.