### PR TITLE
Added support to send multiple commands to multiple devices at once

### DIFF
--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -679,7 +679,7 @@ class OverkizClient:
         }
         response: dict = await self.__post("exec/apply", payload)
         return cast(str, response["execId"])
-   
+
     @retry_on_auth_error
     async def execute_actions(
         self,
@@ -696,7 +696,7 @@ class OverkizClient:
         }
         response: dict = await self.__post("exec/apply", payload)
         return cast(str, response["execId"])
-      
+
     @retry_on_auth_error
     async def get_scenarios(self) -> list[Scenario]:
         """List the scenarios"""


### PR DESCRIPTION
My change adds support for sending multiple commands to multiple devices at once. I wanted to control multiple windows covers from Home Assistant using Local API and found out that it was slower and was causing issues when I wanted to close all my covers at once (10 devices) for example.

I started working on a modification for the core Overkiz integration in Home Assistant to support this use case from scripts, but realized that I needed to add the support to the API Client first.

Sample usage:
```
client.execute_actions(
    [
        Action(device_url1, [Command(OverkizCommand.CLOSE)]),
        Action(device_url2, [Command(OverkizCommand.CLOSE)]),
    ]
)
```