### PR TITLE
Convert integer values to float in value_as_float() function

### DIFF
--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -332,7 +332,7 @@ class State:
         if self.type == DataType.FLOAT:
             return cast(float, self.value)
         if self.type == DataType.INTEGER:
-            return cast(int, self.value)
+            return float(cast(int, self.value))
         raise TypeError(f"{self.name} is not a float")
 
     @property


### PR DESCRIPTION
Variables can sometimes be of type integer, which generates an error line 334