### PR TITLE
Implement reusable backoff decorators to reduce code duplication

### DIFF
--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -97,6 +97,34 @@ async def refresh_listener(invocation: Mapping[str, Any]) -> None:
     await invocation["args"][0].register_event_listener()
 
 
+# Reusable backoff decorators to reduce code duplication
+retry_on_auth_error = backoff.on_exception(
+    backoff.expo,
+    (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
+    max_tries=2,
+    on_backoff=relogin,
+)
+
+retry_on_concurrent_requests = backoff.on_exception(
+    backoff.expo,
+    TooManyConcurrentRequestsException,
+    max_tries=5,
+)
+
+retry_on_too_many_executions = backoff.on_exception(
+    backoff.expo,
+    TooManyExecutionsException,
+    max_tries=10,
+)
+
+retry_on_listener_error = backoff.on_exception(
+    backoff.expo,
+    (InvalidEventListenerIdException, NoRegisteredEventListenerException),
+    max_tries=2,
+    on_backoff=refresh_listener,
+)
+
+
 # pylint: disable=too-many-instance-attributes, too-many-branches
 
 
@@ -416,12 +444,7 @@ class OverkizClient:
 
             return cast(str, token["token"])
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def get_setup(self, refresh: bool = False) -> Setup:
         """
         Get all data about the connected user setup
@@ -453,12 +476,7 @@ class OverkizClient:
 
         return setup
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def get_diagnostic_data(self) -> JSON:
         """
         Get all data about the connected user setup
@@ -473,12 +491,7 @@ class OverkizClient:
 
         return obfuscate_sensitive_data(response)
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def get_devices(self, refresh: bool = False) -> list[Device]:
         """
         List devices
@@ -497,12 +510,7 @@ class OverkizClient:
 
         return devices
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def get_gateways(self, refresh: bool = False) -> list[Gateway]:
         """
         Get every gateways of a connected user setup
@@ -521,12 +529,7 @@ class OverkizClient:
 
         return gateways
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def get_execution_history(self) -> list[HistoryExecution]:
         """
         List execution history
@@ -536,12 +539,7 @@ class OverkizClient:
 
         return execution_history
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def get_device_definition(self, deviceurl: str) -> JSON | None:
         """
         Retrieve a particular setup device definition
@@ -552,12 +550,7 @@ class OverkizClient:
 
         return response.get("definition")
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def get_state(self, deviceurl: str) -> list[State]:
         """
         Retrieve states of requested device
@@ -569,24 +562,14 @@ class OverkizClient:
 
         return state
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def refresh_states(self) -> None:
         """
         Ask the box to refresh all devices states for protocols supporting that operation
         """
         await self.__post("setup/devices/states/refresh")
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def refresh_device_states(self, deviceurl: str) -> None:
         """
         Ask the box to refresh all states of the given device for protocols supporting that operation
@@ -595,7 +578,7 @@ class OverkizClient:
             f"setup/devices/{urllib.parse.quote_plus(deviceurl)}/states/refresh"
         )
 
-    @backoff.on_exception(backoff.expo, TooManyConcurrentRequestsException, max_tries=5)
+    @retry_on_concurrent_requests
     async def register_event_listener(self) -> str:
         """
         Register a new setup event listener on the current session and return a new
@@ -612,19 +595,9 @@ class OverkizClient:
 
         return listener_id
 
-    @backoff.on_exception(backoff.expo, TooManyConcurrentRequestsException, max_tries=5)
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
-    @backoff.on_exception(
-        backoff.expo,
-        (InvalidEventListenerIdException, NoRegisteredEventListenerException),
-        max_tries=2,
-        on_backoff=refresh_listener,
-    )
+    @retry_on_concurrent_requests
+    @retry_on_auth_error
+    @retry_on_listener_error
     async def fetch_events(self) -> list[Event]:
         """
         Fetch new events from a registered event listener. Fetched events are removed
@@ -647,12 +620,7 @@ class OverkizClient:
         await self.__post(f"events/{self.event_listener_id}/unregister")
         self.event_listener_id = None
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def get_current_execution(self, exec_id: str) -> Execution:
         """Get an action group execution currently running"""
         response = await self.__get(f"exec/current/{exec_id}")
@@ -660,12 +628,7 @@ class OverkizClient:
 
         return execution
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def get_current_executions(self) -> list[Execution]:
         """Get all action groups executions currently running"""
         response = await self.__get("exec/current")
@@ -673,25 +636,15 @@ class OverkizClient:
 
         return executions
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def get_api_version(self) -> str:
         """Get the API version (local only)"""
         response = await self.__get("apiVersion")
 
         return cast(str, response["protocolVersion"])
 
-    @backoff.on_exception(backoff.expo, TooManyExecutionsException, max_tries=10)
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_too_many_executions
+    @retry_on_auth_error
     async def execute_command(
         self,
         device_url: str,
@@ -706,22 +659,12 @@ class OverkizClient:
 
         return response
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def cancel_command(self, exec_id: str) -> None:
         """Cancel a running setup-level execution"""
         await self.__delete(f"/exec/current/setup/{exec_id}")
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def execute_commands(
         self,
         device_url: str,
@@ -736,35 +679,20 @@ class OverkizClient:
         response: dict = await self.__post("exec/apply", payload)
         return cast(str, response["execId"])
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def get_scenarios(self) -> list[Scenario]:
         """List the scenarios"""
         response = await self.__get("actionGroups")
         return [Scenario(**scenario) for scenario in response]
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def get_places(self) -> Place:
         """List the places"""
         response = await self.__get("setup/places")
         places = Place(**humps.decamelize(response))
         return places
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def generate_local_token(self, gateway_id: str) -> str:
         """
         Generates a new token
@@ -774,12 +702,7 @@ class OverkizClient:
 
         return cast(str, response["token"])
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def activate_local_token(
         self, gateway_id: str, token: str, label: str, scope: str = "devmode"
     ) -> str:
@@ -794,12 +717,7 @@ class OverkizClient:
 
         return cast(str, response["requestId"])
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def get_local_tokens(
         self, gateway_id: str, scope: str = "devmode"
     ) -> list[LocalToken]:
@@ -812,12 +730,7 @@ class OverkizClient:
 
         return local_tokens
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def delete_local_token(self, gateway_id: str, uuid: str) -> bool:
         """
         Delete a token
@@ -827,34 +740,19 @@ class OverkizClient:
 
         return True
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def execute_scenario(self, oid: str) -> str:
         """Execute a scenario"""
         response = await self.__post(f"exec/{oid}")
         return cast(str, response["execId"])
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def execute_scheduled_scenario(self, oid: str, timestamp: int) -> str:
         """Execute a scheduled scenario"""
         response = await self.__post(f"exec/schedule/{oid}/{timestamp}")
         return cast(str, response["triggerId"])
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def get_setup_options(self) -> list[Option]:
         """
         This operation returns all subscribed options of a given setup.
@@ -866,12 +764,7 @@ class OverkizClient:
 
         return options
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def get_setup_option(self, option: str) -> Option | None:
         """
         This operation returns the selected subscribed option of a given setup.
@@ -884,12 +777,7 @@ class OverkizClient:
 
         return None
 
-    @backoff.on_exception(
-        backoff.expo,
-        (NotAuthenticatedException, ServerDisconnectedError, ClientConnectorError),
-        max_tries=2,
-        on_backoff=relogin,
-    )
+    @retry_on_auth_error
     async def get_setup_option_parameter(
         self, option: str, parameter: str
     ) -> OptionParameter | None:


### PR DESCRIPTION
This pull request refactors the retry logic in the `pyoverkiz/client.py` file to reduce code duplication and improve maintainability. The main change is the introduction of reusable backoff decorators for different categories of exceptions, which are then applied throughout the class methods in place of repeated `@backoff.on_exception` definitions.

Key changes include:

**Refactoring and Code Simplification:**

* Introduced reusable decorators (`retry_on_auth_error`, `retry_on_concurrent_requests`, `retry_on_too_many_executions`, and `retry_on_listener_error`) for common backoff patterns, reducing code duplication and centralizing retry logic.

* Replaced all method-level `@backoff.on_exception` decorators with the new reusable decorators across the client methods, including methods for setup retrieval, device management, event listener registration, execution handling, and scenario management. [[1]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L419-R447) [[2]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L456-R479) [[3]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L476-R494) [[4]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L500-R513) [[5]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L524-R532) [[6]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L539-R542) [[7]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L555-R553) [[8]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L572-R572) [[9]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L598-R581) [[10]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L615-R600) [[11]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L650-R647) [[12]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L709-R667) [[13]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L739-R695) [[14]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L777-R705) [[15]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L797-R720) [[16]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L815-R733) [[17]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L830-R755) [[18]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L869-R767) [[19]](diffhunk://#diff-11513003e65960c0b1a4bccb3c6bf2b7dea08c03923a8e53b8dea1a05f213aa2L887-R780)

This update makes the codebase cleaner and easier to maintain by consolidating retry logic and reducing repetitive code.