### PR TITLE
refactor(tests): use explicit assertions following Python idioms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ select = [
 ]
 ignore = ["E501"] # Line too long
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101"]  # Allow assert in tests
+
 [tool.ruff.lint.pydocstyle]
 convention = "google"  # Accepts: "google", "numpy", or "pep257".
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,64 @@
+"""Shared pytest fixtures for the test suite."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+import pytest_asyncio
+
+from pyoverkiz.client import OverkizClient
+from pyoverkiz.const import SUPPORTED_SERVERS
+from pyoverkiz.utils import generate_local_server
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+class MockResponse:
+    """Simple stand-in for aiohttp responses used in tests."""
+
+    def __init__(self, text: str | None, status: int = 200, url: str = "") -> None:
+        """Create a mock response with text payload and optional status/url."""
+        self._text = text
+        self.status = status
+        self.url = url
+
+    async def text(self) -> str | None:
+        """Return text payload asynchronously."""
+        return self._text
+
+    async def json(self, content_type: str | None = None) -> dict:
+        """Return parsed JSON payload asynchronously."""
+        return json.loads(self._text)
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        """Context manager exit (noop)."""
+        pass
+
+    async def __aenter__(self) -> "MockResponse":
+        """Context manager enter returning self."""
+        return self
+
+
+@pytest.fixture
+def mock_response() -> type[MockResponse]:
+    """Provide the MockResponse class for creating mock responses."""
+    return MockResponse
+
+
+@pytest_asyncio.fixture
+async def client() -> OverkizClient:
+    """Fixture providing an OverkizClient configured for the cloud server."""
+    return OverkizClient("username", "password", SUPPORTED_SERVERS["somfy_europe"])
+
+
+@pytest_asyncio.fixture
+async def local_client() -> OverkizClient:
+    """Fixture providing an OverkizClient configured for a local (developer) server."""
+    return OverkizClient(
+        "username",
+        "password",
+        generate_local_server("gateway-1234-5678-1243.local:8443"),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from pyoverkiz.const import SUPPORTED_SERVERS
 from pyoverkiz.utils import generate_local_server
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    pass
 
 
 class MockResponse:
@@ -37,7 +37,7 @@ class MockResponse:
         """Context manager exit (noop)."""
         pass
 
-    async def __aenter__(self) -> "MockResponse":
+    async def __aenter__(self) -> MockResponse:
         """Context manager enter returning self."""
         return self
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,29 +3,24 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
 
-import pytest
 import pytest_asyncio
 
 from pyoverkiz.client import OverkizClient
 from pyoverkiz.const import SUPPORTED_SERVERS
 from pyoverkiz.utils import generate_local_server
 
-if TYPE_CHECKING:
-    pass
-
 
 class MockResponse:
     """Simple stand-in for aiohttp responses used in tests."""
 
-    def __init__(self, text: str | None, status: int = 200, url: str = "") -> None:
+    def __init__(self, text: str, status: int = 200, url: str = "") -> None:
         """Create a mock response with text payload and optional status/url."""
         self._text = text
         self.status = status
         self.url = url
 
-    async def text(self) -> str | None:
+    async def text(self) -> str:
         """Return text payload asynchronously."""
         return self._text
 
@@ -40,12 +35,6 @@ class MockResponse:
     async def __aenter__(self) -> MockResponse:
         """Context manager enter returning self."""
         return self
-
-
-@pytest.fixture
-def mock_response() -> type[MockResponse]:
-    """Provide the MockResponse class for creating mock responses."""
-    return MockResponse
 
 
 @pytest_asyncio.fixture

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import json
-import os
+from pathlib import Path
 from unittest.mock import patch
 
 import aiohttp
@@ -20,7 +20,7 @@ from pyoverkiz.enums import APIType, DataType
 from pyoverkiz.models import Option
 from pyoverkiz.utils import generate_local_server
 
-CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+CURRENT_DIR = Path(__file__).parent
 
 
 class TestOverkizClient:
@@ -53,9 +53,7 @@ class TestOverkizClient:
     @pytest.mark.asyncio
     async def test_get_devices_basic(self, client: OverkizClient):
         """Ensure the client can fetch and parse the basic devices fixture."""
-        with open(
-            os.path.join(CURRENT_DIR, "devices.json"), encoding="utf-8"
-        ) as raw_devices:
+        with open(CURRENT_DIR / "devices.json", encoding="utf-8") as raw_devices:
             resp = MockResponse(raw_devices.read())
 
         with patch.object(aiohttp.ClientSession, "get", return_value=resp):
@@ -75,7 +73,7 @@ class TestOverkizClient:
     ):
         """Parameterised test that fetches events fixture and checks the expected count."""
         with open(
-            os.path.join(CURRENT_DIR, "fixtures/event/" + fixture_name),
+            CURRENT_DIR / "fixtures" / "event" / fixture_name,
             encoding="utf-8",
         ) as raw_events:
             resp = MockResponse(raw_events.read())
@@ -88,7 +86,7 @@ class TestOverkizClient:
     async def test_fetch_events_simple_cast(self, client: OverkizClient):
         """Check that event state values from the cloud (strings) are cast to appropriate types."""
         with open(
-            os.path.join(CURRENT_DIR, "fixtures/event/events.json"), encoding="utf-8"
+            CURRENT_DIR / "fixtures" / "event" / "events.json", encoding="utf-8"
         ) as raw_events:
             resp = MockResponse(raw_events.read())
 
@@ -112,7 +110,7 @@ class TestOverkizClient:
     async def test_fetch_events_casting(self, client: OverkizClient, fixture_name: str):
         """Validate that fetched event states are cast to the expected Python types for each data type."""
         with open(
-            os.path.join(CURRENT_DIR, "fixtures/event/" + fixture_name),
+            CURRENT_DIR / "fixtures" / "event" / fixture_name,
             encoding="utf-8",
         ) as raw_events:
             resp = MockResponse(raw_events.read())
@@ -181,7 +179,7 @@ class TestOverkizClient:
     ):
         """Ensure setup parsing yields expected device and gateway counts and device metadata."""
         with open(
-            os.path.join(CURRENT_DIR, "fixtures/setup/" + fixture_name),
+            CURRENT_DIR / "fixtures" / "setup" / fixture_name,
             encoding="utf-8",
         ) as setup_mock:
             resp = MockResponse(setup_mock.read())
@@ -230,7 +228,7 @@ class TestOverkizClient:
     async def test_get_diagnostic_data(self, client: OverkizClient, fixture_name: str):
         """Verify that diagnostic data can be fetched and is not empty."""
         with open(
-            os.path.join(CURRENT_DIR, "fixtures/setup/" + fixture_name),
+            CURRENT_DIR / "fixtures" / "setup" / fixture_name,
             encoding="utf-8",
         ) as setup_mock:
             resp = MockResponse(setup_mock.read())
@@ -354,7 +352,7 @@ class TestOverkizClient:
         with pytest.raises(exception):
             if fixture_name:
                 with open(
-                    os.path.join(CURRENT_DIR, "fixtures/exceptions/" + fixture_name),
+                    CURRENT_DIR / "fixtures" / "exceptions" / fixture_name,
                     encoding="utf-8",
                 ) as raw_events:
                     resp = MockResponse(raw_events.read(), status_code)
@@ -370,7 +368,7 @@ class TestOverkizClient:
     ):
         """Check that setup options are parsed and return the expected number of Option instances."""
         with open(
-            os.path.join(CURRENT_DIR, "fixtures/endpoints/setup-options.json"),
+            CURRENT_DIR / "fixtures" / "endpoints" / "setup-options.json",
             encoding="utf-8",
         ) as raw_events:
             resp = MockResponse(raw_events.read())
@@ -403,7 +401,7 @@ class TestOverkizClient:
     ):
         """Verify retrieval of a single setup option by name, including non-existent options."""
         with open(
-            os.path.join(CURRENT_DIR, "fixtures/endpoints/" + fixture_name),
+            CURRENT_DIR / "fixtures" / "endpoints" / fixture_name,
             encoding="utf-8",
         ) as raw_events:
             resp = MockResponse(raw_events.read())
@@ -434,7 +432,7 @@ class TestOverkizClient:
     ):
         """Ensure action groups (scenarios) are parsed correctly and contain actions and commands."""
         with open(
-            os.path.join(CURRENT_DIR, "fixtures/action_groups/" + fixture_name),
+            CURRENT_DIR / "fixtures" / "action_groups" / fixture_name,
             encoding="utf-8",
         ) as action_group_mock:
             resp = MockResponse(action_group_mock.read())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,40 +5,23 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from unittest.mock import patch
 
 import aiohttp
 import pytest
-from pytest_asyncio import fixture
 
 from pyoverkiz import exceptions
 from pyoverkiz.client import OverkizClient
-from pyoverkiz.const import SUPPORTED_SERVERS
 from pyoverkiz.enums import APIType, DataType
 from pyoverkiz.models import Option
-from pyoverkiz.utils import generate_local_server
+from tests.conftest import MockResponse
 
 CURRENT_DIR = Path(__file__).parent
 
 
 class TestOverkizClient:
     """Tests for the public OverkizClient behaviour (API type, devices, events, setup and diagnostics)."""
-
-    @fixture
-    async def client(self):
-        """Fixture providing an OverkizClient configured for the cloud server."""
-        return OverkizClient("username", "password", SUPPORTED_SERVERS["somfy_europe"])
-
-    @fixture
-    async def local_client(self):
-        """Fixture providing an OverkizClient configured for a local (developer) server."""
-        return OverkizClient(
-            "username",
-            "password",
-            generate_local_server("gateway-1234-5678-1243.local:8443"),
-        )
 
     @pytest.mark.asyncio
     async def test_get_api_type_cloud(self, client: OverkizClient):
@@ -453,30 +436,3 @@ class TestOverkizClient:
 
                     for command in action.commands:
                         assert command.name is not None
-
-
-class MockResponse:
-    """Simple stand-in for aiohttp responses used in tests."""
-
-    def __init__(self, text, status=200, url=""):
-        """Create a mock response with text payload and optional status/url."""
-        self._text = text
-        self.status = status
-        self.url = url
-
-    async def text(self):
-        """Return text payload asynchronously."""
-        return self._text
-
-    # pylint: disable=unused-argument
-    async def json(self, content_type=None):
-        """Return parsed JSON payload asynchronously."""
-        return json.loads(self._text)
-
-    async def __aexit__(self, exc_type, exc, tb):
-        """Context manager exit (noop)."""
-        pass
-
-    async def __aenter__(self):
-        """Context manager enter returning self."""
-        return self

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,6 @@
 """Unit tests for the high-level OverkizClient behaviour and responses."""
 
-# ruff: noqa: S101, ASYNC230
-# S101: Tests use assert statements
+# ruff: noqa: ASYNC230
 # ASYNC230: Blocking open() is acceptable for reading test fixtures
 
 from __future__ import annotations

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -194,9 +194,9 @@ class TestOverkizClient:
             assert len(setup.gateways) == gateway_count
 
             for device in setup.devices:
-                assert device.gateway_id
-                assert device.device_address
-                assert device.protocol
+                assert device.gateway_id is not None
+                assert device.device_address is not None
+                assert device.protocol is not None
 
     @pytest.mark.parametrize(
         "fixture_name",
@@ -238,7 +238,7 @@ class TestOverkizClient:
 
         with patch.object(aiohttp.ClientSession, "get", return_value=resp):
             diagnostics = await client.get_diagnostic_data()
-            assert diagnostics
+            assert diagnostics is not None
 
     @pytest.mark.parametrize(
         "fixture_name, exception, status_code",
@@ -446,16 +446,16 @@ class TestOverkizClient:
             assert len(scenarios) == scenario_count
 
             for scenario in scenarios:
-                assert scenario.oid
+                assert scenario.oid is not None
                 assert scenario.label is not None
                 assert scenario.actions
 
                 for action in scenario.actions:
-                    assert action.device_url
+                    assert action.device_url is not None
                     assert action.commands
 
                     for command in action.commands:
-                        assert command.name
+                        assert command.name is not None
 
 
 class MockResponse:

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,8 +1,5 @@
 """Tests for enum helper behaviour and expected values."""
 
-# ruff: noqa: S101
-# Tests use assert statements
-
 from pyoverkiz.enums import (
     EventName,
     ExecutionSubType,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -201,7 +201,7 @@ class TestDevice:
         hump_device = humps.decamelize(RAW_DEVICES)
         del hump_device["states"]
         device = Device(**hump_device)
-        assert not device.states.get(STATE)
+        assert device.states.get(STATE) is None
 
 
 class TestStates:
@@ -211,19 +211,19 @@ class TestStates:
         """An empty list yields an empty States object with no state found."""
         states = States([])
         assert not states
-        assert not states.get(STATE)
+        assert states.get(STATE) is None
 
     def test_none_states(self):
         """A None value for states should behave as empty."""
         states = States(None)
         assert not states
-        assert not states.get(STATE)
+        assert states.get(STATE) is None
 
     def test_getter(self):
         """Retrieve a known state and validate its properties."""
         states = States(RAW_STATES)
         state = states.get(STATE)
-        assert state
+        assert state is not None
         assert state.name == STATE
         assert state.type == DataType.STRING
         assert state.value == "alarm name"
@@ -232,7 +232,7 @@ class TestStates:
         """Requesting a missing state returns falsy (None)."""
         states = States(RAW_STATES)
         state = states.get("FooState")
-        assert not state
+        assert state is None
 
 
 class TestState:
@@ -246,8 +246,7 @@ class TestState:
     def test_bad_int_value(self):
         """Accessor raises TypeError if the state type mismatches expected int."""
         state = State(name="state", type=DataType.BOOLEAN, value=False)
-        with pytest.raises(TypeError):
-            assert state.value_as_int
+        pytest.raises(TypeError, lambda: state.value_as_int)
 
     def test_float_value(self):
         """Float typed state returns proper float accessor."""
@@ -257,8 +256,7 @@ class TestState:
     def test_bad_float_value(self):
         """Accessor raises TypeError if the state type mismatches expected float."""
         state = State(name="state", type=DataType.BOOLEAN, value=False)
-        with pytest.raises(TypeError):
-            assert state.value_as_float
+        pytest.raises(TypeError, lambda: state.value_as_float)
 
     def test_bool_value(self):
         """Boolean typed state returns proper boolean accessor."""
@@ -268,8 +266,7 @@ class TestState:
     def test_bad_bool_value(self):
         """Accessor raises TypeError if the state type mismatches expected bool."""
         state = State(name="state", type=DataType.INTEGER, value=1)
-        with pytest.raises(TypeError):
-            assert state.value_as_bool
+        pytest.raises(TypeError, lambda: state.value_as_bool)
 
     def test_str_value(self):
         """String typed state returns proper string accessor."""
@@ -279,8 +276,7 @@ class TestState:
     def test_bad_str_value(self):
         """Accessor raises TypeError if the state type mismatches expected string."""
         state = State(name="state", type=DataType.BOOLEAN, value=False)
-        with pytest.raises(TypeError):
-            assert state.value_as_str
+        pytest.raises(TypeError, lambda: state.value_as_str)
 
     def test_dict_value(self):
         """JSON object typed state returns proper dict accessor."""
@@ -290,8 +286,7 @@ class TestState:
     def test_bad_dict_value(self):
         """Accessor raises TypeError if the state type mismatches expected dict."""
         state = State(name="state", type=DataType.BOOLEAN, value=False)
-        with pytest.raises(TypeError):
-            assert state.value_as_dict
+        pytest.raises(TypeError, lambda: state.value_as_dict)
 
     def test_list_value(self):
         """JSON array typed state returns proper list accessor."""
@@ -301,5 +296,4 @@ class TestState:
     def test_bad_list_value(self):
         """Accessor raises TypeError if the state type mismatches expected list."""
         state = State(name="state", type=DataType.BOOLEAN, value=False)
-        with pytest.raises(TypeError):
-            assert state.value_as_list
+        pytest.raises(TypeError, lambda: state.value_as_list)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,5 @@
 """Unit tests for models (Device, State and States helpers)."""
 
-# ruff: noqa: S101
-# Tests use assert statements
-
 from __future__ import annotations
 
 import humps

--- a/tests/test_obfuscate.py
+++ b/tests/test_obfuscate.py
@@ -1,8 +1,5 @@
 """Tests for the obfuscation utilities used in fixtures and logging."""
 
-# ruff: noqa: S101
-# Tests use assert statements
-
 import pytest
 
 from pyoverkiz.obfuscate import obfuscate_email, obfuscate_sensitive_data

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,5 @@
 """Tests for utility helper functions like server generation and gateway checks."""
 
-# ruff: noqa: S101
-# Tests use assert statements
-
 import pytest
 
 from pyoverkiz.utils import generate_local_server, is_overkiz_gateway

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,7 @@ class TestUtils:
         """Create a local server descriptor using the host and default values."""
         local_server = generate_local_server(host=LOCAL_HOST)
 
-        assert local_server
+        assert local_server is not None
         assert (
             local_server.endpoint
             == "https://gateway-1234-5678-1243.local:8443/enduser-mobile-web/1/enduserAPI/"
@@ -36,7 +36,7 @@ class TestUtils:
             configuration_url="https://somfy.com",
         )
 
-        assert local_server
+        assert local_server is not None
         assert (
             local_server.endpoint
             == "https://192.168.1.105:8443/enduser-mobile-web/1/enduserAPI/"


### PR DESCRIPTION
## Summary

Modernizes the test suite with Python best practices:

- Use `is None` / `is not None` for explicit None checks (PEP 8)
- Use `pytest.raises()` pattern for exception tests
- Add ruff `per-file-ignores` for S101 in tests, removing redundant inline `# noqa` comments
- Replace `os.path` with `pathlib.Path` in test_client.py
- Extract shared fixtures (`MockResponse`, `client`, `local_client`) to `tests/conftest.py`

## Test Plan

- [x] All 129 tests pass
- [x] Pre-commit checks pass (ruff, mypy, ty)