### PR TITLE
Improve backoff mechanism for TimeoutError

### DIFF
--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -113,7 +113,7 @@ retry_on_auth_error = backoff.on_exception(
 retry_on_connection_failure = backoff.on_exception(
     backoff.expo,
     (TimeoutError, ClientConnectorError),
-    max_tries=10,
+    max_tries=5,
 )
 
 retry_on_concurrent_requests = backoff.on_exception(


### PR DESCRIPTION
A first try to fix #154906. We will need to add better debug logging to Overkiz in core, to see the `backoff` retries and also understand if `TimeoutError` or `ClientConnectorError` is raised.

Adding `retry_on_execution_queue_full` for future purposes.