### PR TITLE
Refactor Nexity authentication to use inline lazy imports

### DIFF
--- a/pyoverkiz/auth/strategies.py
+++ b/pyoverkiz/auth/strategies.py
@@ -6,17 +6,13 @@ import asyncio
 import base64
 import binascii
 import datetime
+import importlib
 import json
 import ssl
 from collections.abc import Mapping
 from typing import Any, cast
 
-import boto3
 from aiohttp import ClientSession, FormData
-from botocore.client import BaseClient
-from botocore.config import Config
-from botocore.exceptions import ClientError
-from warrant_lite import WarrantLite
 
 from pyoverkiz.auth.base import AuthContext, AuthStrategy
 from pyoverkiz.auth.credentials import (
@@ -258,14 +254,17 @@ class NexityAuthStrategy(SessionLoginStrategy):
     async def login(self) -> None:
         """Perform login using Nexity username and password."""
         loop = asyncio.get_running_loop()
+        boto3_module, config_class, client_error_class, warrant_lite_class = (
+            _load_nexity_auth_dependencies()
+        )
 
-        def _client() -> BaseClient:
-            return boto3.client(
-                "cognito-idp", config=Config(region_name=NEXITY_COGNITO_REGION)
+        def _client() -> Any:
+            return boto3_module.client(
+                "cognito-idp", config=config_class(region_name=NEXITY_COGNITO_REGION)
             )
 
         client = await loop.run_in_executor(None, _client)
-        aws = WarrantLite(
+        aws = warrant_lite_class(
             username=self.credentials.username,
             password=self.credentials.password,
             pool_id=NEXITY_COGNITO_USER_POOL,
@@ -275,8 +274,9 @@ class NexityAuthStrategy(SessionLoginStrategy):
 
         try:
             tokens = await loop.run_in_executor(None, aws.authenticate_user)
-        except ClientError as error:
-            code = error.response.get("Error", {}).get("Code")
+        except client_error_class as error:
+            client_error = cast(Any, error)
+            code = client_error.response.get("Error", {}).get("Code")
             if code in {"NotAuthorizedException", "UserNotFoundException"}:
                 raise NexityBadCredentialsException() from error
             raise
@@ -436,6 +436,27 @@ class BearerTokenAuthStrategy(BaseAuthStrategy):
         if self.credentials.token:
             return {"Authorization": f"Bearer {self.credentials.token}"}
         return {}
+
+
+def _load_nexity_auth_dependencies() -> tuple[Any, Any, type[Exception], Any]:
+    """Load Nexity optional dependencies only when Nexity auth is used."""
+    try:
+        boto3_module = importlib.import_module("boto3")
+        botocore_config_module = importlib.import_module("botocore.config")
+        botocore_exceptions_module = importlib.import_module("botocore.exceptions")
+        warrant_lite_module = importlib.import_module("warrant_lite")
+    except ImportError as error:
+        raise NexityServiceException(
+            "Nexity authentication requires optional dependencies. Install with the "
+            "Nexity auth extras."
+        ) from error
+
+    return (
+        boto3_module,
+        botocore_config_module.Config,
+        cast(type[Exception], botocore_exceptions_module.ClientError),
+        warrant_lite_module.WarrantLite,
+    )
 
 
 def _decode_jwt_payload(token: str) -> dict[str, Any]:

--- a/pyoverkiz/auth/strategies.py
+++ b/pyoverkiz/auth/strategies.py
@@ -6,7 +6,6 @@ import asyncio
 import base64
 import binascii
 import datetime
-import importlib
 import json
 import ssl
 from collections.abc import Mapping
@@ -253,18 +252,26 @@ class NexityAuthStrategy(SessionLoginStrategy):
 
     async def login(self) -> None:
         """Perform login using Nexity username and password."""
+        try:
+            import boto3
+            from botocore.config import Config
+            from botocore.exceptions import ClientError
+            from warrant_lite import WarrantLite
+        except ImportError as error:
+            raise NexityServiceException(
+                "Nexity authentication requires optional dependencies. Install with the "
+                "Nexity auth extras."
+            ) from error
+
         loop = asyncio.get_running_loop()
-        boto3_module, config_class, client_error_class, warrant_lite_class = (
-            _load_nexity_auth_dependencies()
-        )
 
         def _client() -> Any:
-            return boto3_module.client(
-                "cognito-idp", config=config_class(region_name=NEXITY_COGNITO_REGION)
+            return boto3.client(
+                "cognito-idp", config=Config(region_name=NEXITY_COGNITO_REGION)
             )
 
         client = await loop.run_in_executor(None, _client)
-        aws = warrant_lite_class(
+        aws = WarrantLite(
             username=self.credentials.username,
             password=self.credentials.password,
             pool_id=NEXITY_COGNITO_USER_POOL,
@@ -274,9 +281,8 @@ class NexityAuthStrategy(SessionLoginStrategy):
 
         try:
             tokens = await loop.run_in_executor(None, aws.authenticate_user)
-        except client_error_class as error:
-            client_error = cast(Any, error)
-            code = client_error.response.get("Error", {}).get("Code")
+        except ClientError as error:
+            code = error.response.get("Error", {}).get("Code")
             if code in {"NotAuthorizedException", "UserNotFoundException"}:
                 raise NexityBadCredentialsException() from error
             raise
@@ -436,27 +442,6 @@ class BearerTokenAuthStrategy(BaseAuthStrategy):
         if self.credentials.token:
             return {"Authorization": f"Bearer {self.credentials.token}"}
         return {}
-
-
-def _load_nexity_auth_dependencies() -> tuple[Any, Any, type[Exception], Any]:
-    """Load Nexity optional dependencies only when Nexity auth is used."""
-    try:
-        boto3_module = importlib.import_module("boto3")
-        botocore_config_module = importlib.import_module("botocore.config")
-        botocore_exceptions_module = importlib.import_module("botocore.exceptions")
-        warrant_lite_module = importlib.import_module("warrant_lite")
-    except ImportError as error:
-        raise NexityServiceException(
-            "Nexity authentication requires optional dependencies. Install with the "
-            "Nexity auth extras."
-        ) from error
-
-    return (
-        boto3_module,
-        botocore_config_module.Config,
-        cast(type[Exception], botocore_exceptions_module.ClientError),
-        warrant_lite_module.WarrantLite,
-    )
 
 
 def _decode_jwt_payload(token: str) -> dict[str, Any]:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -510,11 +510,21 @@ class TestNexityAuthStrategy:
         )
         warrant_instance = MagicMock()
         warrant_instance.authenticate_user.side_effect = bad_credentials_error
+        boto3_module = MagicMock()
+        boto3_module.client.return_value = MagicMock()
+        config_class = MagicMock()
+        client_error_class = ClientError
+        warrant_lite_class = MagicMock(return_value=warrant_instance)
 
         with (
-            patch("pyoverkiz.auth.strategies.boto3.client", return_value=MagicMock()),
             patch(
-                "pyoverkiz.auth.strategies.WarrantLite", return_value=warrant_instance
+                "pyoverkiz.auth.strategies._load_nexity_auth_dependencies",
+                return_value=(
+                    boto3_module,
+                    config_class,
+                    client_error_class,
+                    warrant_lite_class,
+                ),
             ),
             pytest.raises(NexityBadCredentialsException),
         ):
@@ -542,11 +552,21 @@ class TestNexityAuthStrategy:
         )
         warrant_instance = MagicMock()
         warrant_instance.authenticate_user.side_effect = service_error
+        boto3_module = MagicMock()
+        boto3_module.client.return_value = MagicMock()
+        config_class = MagicMock()
+        client_error_class = ClientError
+        warrant_lite_class = MagicMock(return_value=warrant_instance)
 
         with (
-            patch("pyoverkiz.auth.strategies.boto3.client", return_value=MagicMock()),
             patch(
-                "pyoverkiz.auth.strategies.WarrantLite", return_value=warrant_instance
+                "pyoverkiz.auth.strategies._load_nexity_auth_dependencies",
+                return_value=(
+                    boto3_module,
+                    config_class,
+                    client_error_class,
+                    warrant_lite_class,
+                ),
             ),
             pytest.raises(ClientError, match="InternalErrorException"),
         ):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -510,22 +510,12 @@ class TestNexityAuthStrategy:
         )
         warrant_instance = MagicMock()
         warrant_instance.authenticate_user.side_effect = bad_credentials_error
-        boto3_module = MagicMock()
-        boto3_module.client.return_value = MagicMock()
-        config_class = MagicMock()
-        client_error_class = ClientError
-        warrant_lite_class = MagicMock(return_value=warrant_instance)
+        boto3_mock = MagicMock()
+        boto3_mock.client.return_value = MagicMock()
 
         with (
-            patch(
-                "pyoverkiz.auth.strategies._load_nexity_auth_dependencies",
-                return_value=(
-                    boto3_module,
-                    config_class,
-                    client_error_class,
-                    warrant_lite_class,
-                ),
-            ),
+            patch("boto3.client", boto3_mock.client),
+            patch("warrant_lite.WarrantLite", return_value=warrant_instance),
             pytest.raises(NexityBadCredentialsException),
         ):
             strategy = NexityAuthStrategy(
@@ -552,22 +542,12 @@ class TestNexityAuthStrategy:
         )
         warrant_instance = MagicMock()
         warrant_instance.authenticate_user.side_effect = service_error
-        boto3_module = MagicMock()
-        boto3_module.client.return_value = MagicMock()
-        config_class = MagicMock()
-        client_error_class = ClientError
-        warrant_lite_class = MagicMock(return_value=warrant_instance)
+        boto3_mock = MagicMock()
+        boto3_mock.client.return_value = MagicMock()
 
         with (
-            patch(
-                "pyoverkiz.auth.strategies._load_nexity_auth_dependencies",
-                return_value=(
-                    boto3_module,
-                    config_class,
-                    client_error_class,
-                    warrant_lite_class,
-                ),
-            ),
+            patch("boto3.client", boto3_mock.client),
+            patch("warrant_lite.WarrantLite", return_value=warrant_instance),
             pytest.raises(ClientError, match="InternalErrorException"),
         ):
             strategy = NexityAuthStrategy(


### PR DESCRIPTION
Refactors the Nexity authentication strategy to load optional dependencies lazily at runtime using standard inline `import` statements inside the `login()` method, rather than importing them at the module level. This keeps the code readable while avoiding unnecessary imports unless Nexity authentication is actually used.

Dependency loading improvements:

* Moved imports of `boto3`, `botocore.config`, `botocore.exceptions`, and `warrant_lite` from the module level into the body of `NexityAuthStrategy.login()`, using a `try/except ImportError` block to raise a clear `NexityServiceException` if the optional dependencies are missing.
* Removed the intermediate `_load_nexity_auth_dependencies` helper function and the `import importlib` module-level import, restoring full type information (no `Any` or `cast` workarounds).

Testing updates:

* Updated tests to patch `boto3.client` and `warrant_lite.WarrantLite` directly, which is the correct approach when the imports live inside the method body rather than at module level.