### PR TITLE
Rename all exceptions from *Exception to *Error (N818)

### DIFF
--- a/docs/action-queue.md
+++ b/docs/action-queue.md
@@ -1,6 +1,6 @@
 # Action queue
 
-The action queue automatically groups rapid, consecutive calls to `execute_action_group()` into a single ActionGroup execution. This minimizes the number of API calls and helps prevent rate limiting issues, such as `TooManyRequestsException`, `TooManyConcurrentRequestsException`, `TooManyExecutionsException`, or `ExecutionQueueFullException` which can occur if actions are sent individually in quick succession.
+The action queue automatically groups rapid, consecutive calls to `execute_action_group()` into a single ActionGroup execution. This minimizes the number of API calls and helps prevent rate limiting issues, such as `TooManyRequestsError`, `TooManyConcurrentRequestsError`, `TooManyExecutionsError`, or `ExecutionQueueFullError` which can occur if actions are sent individually in quick succession.
 
 Important limitation:
 - Gateways only allow a single action per device in each action group. The queue

--- a/docs/device-control.md
+++ b/docs/device-control.md
@@ -198,7 +198,7 @@ await client.execute_action_group(
 
 ## Limitations and rate limits
 
-Gateways impose limits on how many executions can run or be queued simultaneously. If the execution queue is full, the API will raise an `ExecutionQueueFullException`. Most gateways allow up to 10 concurrent executions.
+Gateways impose limits on how many executions can run or be queued simultaneously. If the execution queue is full, the API will raise an `ExecutionQueueFullError`. Most gateways allow up to 10 concurrent executions.
 
 ### Action queue (batching across calls)
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,14 +1,14 @@
 # Error handling
 
-## Common exceptions
+## Common errors
 
-- `NotAuthenticatedException`
-- `TooManyRequestsException`
-- `TooManyConcurrentRequestsException`
-- `TooManyExecutionsException`
-- `MaintenanceException`
-- `AccessDeniedToGatewayException`
-- `BadCredentialsException`
+- `NotAuthenticatedError`
+- `TooManyRequestsError`
+- `TooManyConcurrentRequestsError`
+- `TooManyExecutionsError`
+- `MaintenanceError`
+- `AccessDeniedToGatewayError`
+- `BadCredentialsError`
 
 ## Retry and backoff guidance
 
@@ -21,9 +21,9 @@ from pyoverkiz.auth.credentials import UsernamePasswordCredentials
 from pyoverkiz.client import OverkizClient
 from pyoverkiz.enums import Server
 from pyoverkiz.exceptions import (
-    NotAuthenticatedException,
-    TooManyConcurrentRequestsException,
-    TooManyRequestsException,
+    NotAuthenticatedError,
+    TooManyConcurrentRequestsError,
+    TooManyRequestsError,
 )
 
 
@@ -38,9 +38,9 @@ async def fetch_devices_with_retry() -> None:
                 devices = await client.get_devices()
                 print(devices)
                 return
-            except (TooManyRequestsException, TooManyConcurrentRequestsException):
+            except (TooManyRequestsError, TooManyConcurrentRequestsError):
                 await asyncio.sleep(0.5 * (attempt + 1))
-            except NotAuthenticatedException:
+            except NotAuthenticatedError:
                 await client.login()
 
 

--- a/docs/event-handling.md
+++ b/docs/event-handling.md
@@ -32,8 +32,8 @@ from pyoverkiz.auth.credentials import UsernamePasswordCredentials
 from pyoverkiz.client import OverkizClient
 from pyoverkiz.enums import Server
 from pyoverkiz.exceptions import (
-    InvalidEventListenerIdException,
-    NoRegisteredEventListenerException,
+    InvalidEventListenerIdError,
+    NoRegisteredEventListenerError,
 )
 
 
@@ -48,7 +48,7 @@ async def main() -> None:
         while True:
             try:
                 events = await client.fetch_events()
-            except (InvalidEventListenerIdException, NoRegisteredEventListenerException):
+            except (InvalidEventListenerIdError, NoRegisteredEventListenerError):
                 await asyncio.sleep(1)
                 await client.register_event_listener()
                 continue
@@ -96,6 +96,6 @@ asyncio.run(main())
 
 ## Reconnect tips
 
-- Re-register the listener when you see `InvalidEventListenerIdException`.
+- Re-register the listener when you see `InvalidEventListenerIdError`.
 - Poll occasionally if your network has unstable connectivity.
 - Keep the fetch loop alive to avoid listener timeout.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,11 +17,11 @@ If the gateway uses a self-signed certificate, pass `verify_ssl=False` when crea
 ## Rate limits and concurrency
 
 - Reduce polling frequency.
-- Back off on `TooManyRequestsException` or `TooManyConcurrentRequestsException`.
+- Back off on `TooManyRequestsError` or `TooManyConcurrentRequestsError`.
 
 ## Listener drops
 
-- Re-register the event listener when you see `InvalidEventListenerIdException`.
+- Re-register the event listener when you see `InvalidEventListenerIdError`.
 - Ensure your fetch loop is running every few seconds.
 
 ## Device not found

--- a/pyoverkiz/auth/strategies.py
+++ b/pyoverkiz/auth/strategies.py
@@ -42,14 +42,14 @@ from pyoverkiz.const import (
 )
 from pyoverkiz.enums import APIType
 from pyoverkiz.exceptions import (
-    BadCredentialsException,
-    CozyTouchBadCredentialsException,
-    CozyTouchServiceException,
-    InvalidTokenException,
-    NexityBadCredentialsException,
-    NexityServiceException,
-    SomfyBadCredentialsException,
-    SomfyServiceException,
+    BadCredentialsError,
+    CozyTouchBadCredentialsError,
+    CozyTouchServiceError,
+    InvalidTokenError,
+    NexityBadCredentialsError,
+    NexityServiceError,
+    SomfyBadCredentialsError,
+    SomfyServiceError,
 )
 from pyoverkiz.models import ServerConfig
 
@@ -118,7 +118,7 @@ class SessionLoginStrategy(BaseAuthStrategy):
             ssl=self._ssl,
         ) as response:
             if response.status not in (200, 204):
-                raise BadCredentialsException(
+                raise BadCredentialsError(
                     f"Login failed for {self.server.name}: {response.status}"
                 )
 
@@ -128,7 +128,7 @@ class SessionLoginStrategy(BaseAuthStrategy):
 
             result = await response.json()
             if not result.get("success"):
-                raise BadCredentialsException("Login failed: bad credentials")
+                raise BadCredentialsError("Login failed: bad credentials")
 
 
 class SomfyAuthStrategy(BaseAuthStrategy):
@@ -195,11 +195,11 @@ class SomfyAuthStrategy(BaseAuthStrategy):
             token = await response.json()
 
             if token.get("message") == "error.invalid.grant":
-                raise SomfyBadCredentialsException(token["message"])
+                raise SomfyBadCredentialsError(token["message"])
 
             access_token = token.get("access_token")
             if not access_token:
-                raise SomfyServiceException("No Somfy access token provided.")
+                raise SomfyServiceError("No Somfy access token provided.")
 
             self.context.access_token = cast(str, access_token)
             self.context.refresh_token = token.get("refresh_token")
@@ -233,10 +233,10 @@ class CozytouchAuthStrategy(SessionLoginStrategy):
             token = await response.json()
 
             if token.get("error") == "invalid_grant":
-                raise CozyTouchBadCredentialsException(token["error_description"])
+                raise CozyTouchBadCredentialsError(token["error_description"])
 
             if "token_type" not in token:
-                raise CozyTouchServiceException("No CozyTouch token provided.")
+                raise CozyTouchServiceError("No CozyTouch token provided.")
 
         async with self.session.get(
             f"{COZYTOUCH_ATLANTIC_API}/magellan/accounts/jwt",
@@ -245,7 +245,7 @@ class CozytouchAuthStrategy(SessionLoginStrategy):
             jwt = await response.text()
 
             if not jwt:
-                raise CozyTouchServiceException("No JWT token provided.")
+                raise CozyTouchServiceError("No JWT token provided.")
 
             jwt = jwt.strip('"')
 
@@ -278,7 +278,7 @@ class NexityAuthStrategy(SessionLoginStrategy):
         except ClientError as error:
             code = error.response.get("Error", {}).get("Code")
             if code in {"NotAuthorizedException", "UserNotFoundException"}:
-                raise NexityBadCredentialsException() from error
+                raise NexityBadCredentialsError() from error
             raise
 
         id_token = tokens["AuthenticationResult"]["IdToken"]
@@ -290,7 +290,7 @@ class NexityAuthStrategy(SessionLoginStrategy):
             token = await response.json()
 
             if "token" not in token:
-                raise NexityServiceException("No Nexity SSO token provided.")
+                raise NexityServiceError("No Nexity SSO token provided.")
 
             user_id = self.credentials.username.replace("@", "_-_")
             await self._post_login({"ssoToken": token["token"], "userId": user_id})
@@ -314,7 +314,7 @@ class LocalTokenAuthStrategy(BaseAuthStrategy):
     async def login(self) -> None:
         """Validate that a token is provided for local API access."""
         if not self.credentials.token:
-            raise InvalidTokenException("Local API requires a token.")
+            raise InvalidTokenError("Local API requires a token.")
 
     def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
         """Return authentication headers for a request path."""
@@ -385,16 +385,14 @@ class RexelAuthStrategy(BaseAuthStrategy):
             if error:
                 description = token.get("error_description") or token.get("message")
                 if description:
-                    raise InvalidTokenException(
+                    raise InvalidTokenError(
                         f"Error retrieving Rexel access token: {description}"
                     )
-                raise InvalidTokenException(
-                    f"Error retrieving Rexel access token: {error}"
-                )
+                raise InvalidTokenError(f"Error retrieving Rexel access token: {error}")
 
             access_token = token.get("access_token")
             if not access_token:
-                raise InvalidTokenException("No Rexel access token provided.")
+                raise InvalidTokenError("No Rexel access token provided.")
 
             self._ensure_consent(access_token)
             self.context.access_token = cast(str, access_token)
@@ -411,9 +409,7 @@ class RexelAuthStrategy(BaseAuthStrategy):
         payload = _decode_jwt_payload(access_token)
         consent = payload.get("consent")
         if consent != REXEL_REQUIRED_CONSENT:
-            raise InvalidTokenException(
-                "Consent is missing or revoked for Rexel token."
-            )
+            raise InvalidTokenError("Consent is missing or revoked for Rexel token.")
 
 
 class BearerTokenAuthStrategy(BaseAuthStrategy):
@@ -442,7 +438,7 @@ def _decode_jwt_payload(token: str) -> dict[str, Any]:
     """Decode the payload of a JWT token."""
     parts = token.split(".")
     if len(parts) < 2:
-        raise InvalidTokenException("Malformed JWT received.")
+        raise InvalidTokenError("Malformed JWT received.")
 
     payload_segment = parts[1]
     padding = "=" * (-len(payload_segment) % 4)
@@ -450,4 +446,4 @@ def _decode_jwt_payload(token: str) -> dict[str, Any]:
         decoded = base64.urlsafe_b64decode(payload_segment + padding)
         return cast(dict[str, Any], json.loads(decoded))
     except (binascii.Error, json.JSONDecodeError) as error:
-        raise InvalidTokenException("Malformed JWT received.") from error
+        raise InvalidTokenError("Malformed JWT received.") from error

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -23,13 +23,13 @@ from pyoverkiz.auth import AuthStrategy, Credentials, build_auth_strategy
 from pyoverkiz.const import SUPPORTED_SERVERS
 from pyoverkiz.enums import APIType, CommandMode, Server
 from pyoverkiz.exceptions import (
-    ExecutionQueueFullException,
-    InvalidEventListenerIdException,
-    NoRegisteredEventListenerException,
-    NotAuthenticatedException,
-    OverkizException,
-    TooManyConcurrentRequestsException,
-    TooManyExecutionsException,
+    ExecutionQueueFullError,
+    InvalidEventListenerIdError,
+    NoRegisteredEventListenerError,
+    NotAuthenticatedError,
+    OverkizError,
+    TooManyConcurrentRequestsError,
+    TooManyExecutionsError,
 )
 from pyoverkiz.models import (
     Action,
@@ -74,7 +74,7 @@ async def refresh_listener(invocation: Details) -> None:
 # Reusable backoff decorators to reduce code duplication
 retry_on_auth_error = backoff.on_exception(
     backoff.expo,
-    (NotAuthenticatedException, ServerDisconnectedError),
+    (NotAuthenticatedError, ServerDisconnectedError),
     max_tries=2,
     on_backoff=relogin,
     logger=_LOGGER,
@@ -89,21 +89,21 @@ retry_on_connection_failure = backoff.on_exception(
 
 retry_on_concurrent_requests = backoff.on_exception(
     backoff.expo,
-    TooManyConcurrentRequestsException,
+    TooManyConcurrentRequestsError,
     max_tries=5,
     logger=_LOGGER,
 )
 
 retry_on_too_many_executions = backoff.on_exception(
     backoff.expo,
-    TooManyExecutionsException,
+    TooManyExecutionsError,
     max_tries=10,
     logger=_LOGGER,
 )
 
 retry_on_listener_error = backoff.on_exception(
     backoff.expo,
-    (InvalidEventListenerIdException, NoRegisteredEventListenerException),
+    (InvalidEventListenerIdError, NoRegisteredEventListenerError),
     max_tries=2,
     on_backoff=refresh_listener,
     logger=_LOGGER,
@@ -111,7 +111,7 @@ retry_on_listener_error = backoff.on_exception(
 
 retry_on_execution_queue_full = backoff.on_exception(
     backoff.expo,
-    ExecutionQueueFullException,
+    ExecutionQueueFullError,
     max_tries=5,
     logger=_LOGGER,
 )
@@ -241,7 +241,7 @@ class OverkizClient:
         try:
             return SUPPORTED_SERVERS[server_key]
         except KeyError as error:
-            raise OverkizException(
+            raise OverkizError(
                 f"Unknown server '{server_key}'. Provide a supported server key or ServerConfig instance."
             ) from error
 
@@ -629,7 +629,7 @@ class OverkizClient:
 
         For example `developerMode-{gateway_id}` and `gatewayId` to understand if developer mode is on.
 
-        If the option is not available, an OverkizException will be thrown.
+        If the option is not available, an OverkizError will be thrown.
         If the parameter is not available you will receive None.
         """
         response = await self._get(f"setup/options/{option}/{parameter}")

--- a/pyoverkiz/exceptions.py
+++ b/pyoverkiz/exceptions.py
@@ -1,136 +1,139 @@
-"""Exceptions defined for Overkiz API and its integrations."""
+"""Errors defined for Overkiz API and its integrations."""
 
 
-class BaseOverkizException(Exception):
-    """Base exception for Overkiz errors."""
+class BaseOverkizError(Exception):
+    """Base error for Overkiz errors."""
 
 
-class OverkizException(BaseOverkizException):
+class OverkizError(BaseOverkizError):
     """Raised when an undefined error occurs while communicating with the Overkiz API."""
 
 
-class BadCredentialsException(BaseOverkizException):
+class BadCredentialsError(BaseOverkizError):
     """Raised when invalid credentials are provided."""
 
 
-class InvalidCommandException(BaseOverkizException):
+class InvalidCommandError(BaseOverkizError):
     """Raised when an invalid command is provided."""
 
 
-class DuplicateActionOnDeviceException(BaseOverkizException):
+class DuplicateActionOnDeviceError(BaseOverkizError):
     """Raised when another action already exists for the same device."""
 
 
-class ActionGroupSetupNotFoundException(BaseOverkizException):
+class ActionGroupSetupNotFoundError(BaseOverkizError):
     """Raised when an action group setup cannot be determined for a gateway."""
 
 
-class NoSuchResourceException(BaseOverkizException):
+class NoSuchResourceError(BaseOverkizError):
     """Raised when an invalid API call is made."""
 
 
-class ResourceAccessDeniedException(BaseOverkizException):
+class ResourceAccessDeniedError(BaseOverkizError):
     """Raised when the API returns a RESOURCE_ACCESS_DENIED error."""
 
 
-class NotAuthenticatedException(ResourceAccessDeniedException):
+class NotAuthenticatedError(ResourceAccessDeniedError):
     """Raised when the user is not authenticated."""
 
 
-class TooManyExecutionsException(BaseOverkizException):
+class TooManyExecutionsError(BaseOverkizError):
     """Raised when too many executions are requested."""
 
 
-class ExecutionQueueFullException(BaseOverkizException):
+class ExecutionQueueFullError(BaseOverkizError):
     """Raised when the execution queue is full."""
 
 
-class TooManyRequestsException(BaseOverkizException):
+class TooManyRequestsError(BaseOverkizError):
     """Raised when too many requests are made."""
 
 
-class TooManyConcurrentRequestsException(BaseOverkizException):
+class TooManyConcurrentRequestsError(BaseOverkizError):
     """Raised when too many concurrent requests are made."""
 
 
-class ServiceUnavailableException(BaseOverkizException):
+class ServiceUnavailableError(BaseOverkizError):
     """Raised when the service is unavailable."""
 
 
-class MaintenanceException(ServiceUnavailableException):
+class MaintenanceError(ServiceUnavailableError):
     """Raised when the service is under maintenance."""
 
 
-class MissingAPIKeyException(BaseOverkizException):
+class MissingAPIKeyError(BaseOverkizError):
     """Raised when the API key is missing."""
 
 
-class MissingAuthorizationTokenException(ResourceAccessDeniedException):
+class MissingAuthorizationTokenError(ResourceAccessDeniedError):
     """Raised when the authorization token is missing."""
 
 
-class InvalidEventListenerIdException(BaseOverkizException):
+class InvalidEventListenerIdError(BaseOverkizError):
     """Raised when an invalid event listener ID is provided."""
 
 
-class NoRegisteredEventListenerException(BaseOverkizException):
+class NoRegisteredEventListenerError(BaseOverkizError):
     """Raised when no event listener is registered."""
 
 
-class SessionAndBearerInSameRequestException(BaseOverkizException):
+class SessionAndBearerInSameRequestError(BaseOverkizError):
     """Raised when both session and bearer are provided in the same request."""
 
 
-class TooManyAttemptsBannedException(BaseOverkizException):
+class TooManyAttemptsBannedError(BaseOverkizError):
     """Raised when too many attempts are made and the user is (temporarily) banned."""
 
 
-class InvalidTokenException(BaseOverkizException):
+class InvalidTokenError(BaseOverkizError):
     """Raised when an invalid token is provided."""
 
 
-class NotSuchTokenException(BaseOverkizException):
+class NoSuchTokenError(BaseOverkizError):
     """Raised when an invalid token is provided."""
 
 
-class UnknownUserException(BaseOverkizException):
+class UnknownUserError(BaseOverkizError):
     """Raised when an unknown user is provided."""
 
 
-class UnknownObjectException(BaseOverkizException):
+class UnknownObjectError(BaseOverkizError):
     """Raised when an unknown object is provided."""
 
 
-class AccessDeniedToGatewayException(ResourceAccessDeniedException):
-    """Raised when access is denied to the gateway. This often happens when the user is not the owner of the gateway."""
+class AccessDeniedToGatewayError(ResourceAccessDeniedError):
+    """Raised when access is denied to the gateway.
+
+    This often happens when the user is not the owner of the gateway.
+    """
 
 
-class ApplicationNotAllowedException(ResourceAccessDeniedException):
+class ApplicationNotAllowedError(ResourceAccessDeniedError):
     """Raised when the setup cannot be accessed through the application."""
 
 
 # Nexity
-class NexityBadCredentialsException(BadCredentialsException):
+class NexityBadCredentialsError(BadCredentialsError):
     """Raised when invalid credentials are provided to Nexity authentication API."""
 
 
-class NexityServiceException(BaseOverkizException):
+class NexityServiceError(BaseOverkizError):
     """Raised when an error occurs while communicating with the Nexity API."""
 
 
 # CozyTouch
-class CozyTouchBadCredentialsException(BadCredentialsException):
+class CozyTouchBadCredentialsError(BadCredentialsError):
     """Raised when invalid credentials are provided to CozyTouch authentication API."""
 
 
-class CozyTouchServiceException(BaseOverkizException):
+class CozyTouchServiceError(BaseOverkizError):
     """Raised when an error occurs while communicating with the CozyTouch API."""
 
 
 # Somfy
-class SomfyBadCredentialsException(BadCredentialsException):
+class SomfyBadCredentialsError(BadCredentialsError):
     """Raised when invalid credentials are provided to Somfy authentication API."""
 
 
-class SomfyServiceException(BaseOverkizException):
+class SomfyServiceError(BaseOverkizError):
     """Raised when an error occurs while communicating with the Somfy API."""

--- a/pyoverkiz/exceptions.py
+++ b/pyoverkiz/exceptions.py
@@ -90,7 +90,7 @@ class InvalidTokenError(BaseOverkizError):
 
 
 class NoSuchTokenError(BaseOverkizError):
-    """Raised when an invalid token is provided."""
+    """Raised when no such token exists."""
 
 
 class UnknownUserError(BaseOverkizError):

--- a/pyoverkiz/response_handler.py
+++ b/pyoverkiz/response_handler.py
@@ -36,7 +36,7 @@ from pyoverkiz.exceptions import (
     UnknownUserError,
 )
 
-# Primary dispatch: (errorCode, message_substring) -> exception class.
+# Primary dispatch: (errorCode, message_substring) -> error class.
 # Checked in order; first match wins. Use errorCode as the primary key to
 # reduce brittleness across cloud vs. local API variants.
 _ERROR_CODE_MESSAGE_MAP: list[tuple[str, str | None, type[BaseOverkizError]]] = [
@@ -141,14 +141,14 @@ async def check_response(response: ClientResponse) -> None:
         message = message.strip('".') if (message := result.get("error")) else ""
 
         # 1. Primary dispatch: match on errorCode (+ optional message substring)
-        for code, pattern, exc_class in _ERROR_CODE_MESSAGE_MAP:
+        for code, pattern, error_class in _ERROR_CODE_MESSAGE_MAP:
             if error_code == code and (pattern is None or pattern in message):
-                raise exc_class(message)
+                raise error_class(message)
 
         # 2. Message-only fallback for patterns that may appear under varying errorCodes
-        for pattern, exc_class in _MESSAGE_FALLBACK_MAP:
+        for pattern, error_class in _MESSAGE_FALLBACK_MAP:
             if pattern in message:
-                raise exc_class(message)
+                raise error_class(message)
 
         # 3. errorCode category fallback (known code, unknown message)
         if error_code in _ERROR_CODE_FALLBACK_MAP:

--- a/pyoverkiz/response_handler.py
+++ b/pyoverkiz/response_handler.py
@@ -1,4 +1,4 @@
-"""Dispatch logic for mapping Overkiz API error responses to specific exceptions."""
+"""Dispatch logic for mapping Overkiz API error responses to specific errors."""
 
 from __future__ import annotations
 
@@ -7,107 +7,107 @@ from json import JSONDecodeError
 from aiohttp import ClientResponse
 
 from pyoverkiz.exceptions import (
-    AccessDeniedToGatewayException,
-    ActionGroupSetupNotFoundException,
-    ApplicationNotAllowedException,
-    BadCredentialsException,
-    BaseOverkizException,
-    DuplicateActionOnDeviceException,
-    ExecutionQueueFullException,
-    InvalidCommandException,
-    InvalidEventListenerIdException,
-    InvalidTokenException,
-    MaintenanceException,
-    MissingAPIKeyException,
-    MissingAuthorizationTokenException,
-    NoRegisteredEventListenerException,
-    NoSuchResourceException,
-    NotAuthenticatedException,
-    NotSuchTokenException,
-    OverkizException,
-    ResourceAccessDeniedException,
-    ServiceUnavailableException,
-    SessionAndBearerInSameRequestException,
-    TooManyAttemptsBannedException,
-    TooManyConcurrentRequestsException,
-    TooManyExecutionsException,
-    TooManyRequestsException,
-    UnknownObjectException,
-    UnknownUserException,
+    AccessDeniedToGatewayError,
+    ActionGroupSetupNotFoundError,
+    ApplicationNotAllowedError,
+    BadCredentialsError,
+    BaseOverkizError,
+    DuplicateActionOnDeviceError,
+    ExecutionQueueFullError,
+    InvalidCommandError,
+    InvalidEventListenerIdError,
+    InvalidTokenError,
+    MaintenanceError,
+    MissingAPIKeyError,
+    MissingAuthorizationTokenError,
+    NoRegisteredEventListenerError,
+    NoSuchResourceError,
+    NoSuchTokenError,
+    NotAuthenticatedError,
+    OverkizError,
+    ResourceAccessDeniedError,
+    ServiceUnavailableError,
+    SessionAndBearerInSameRequestError,
+    TooManyAttemptsBannedError,
+    TooManyConcurrentRequestsError,
+    TooManyExecutionsError,
+    TooManyRequestsError,
+    UnknownObjectError,
+    UnknownUserError,
 )
 
 # Primary dispatch: (errorCode, message_substring) -> exception class.
 # Checked in order; first match wins. Use errorCode as the primary key to
 # reduce brittleness across cloud vs. local API variants.
-_ERROR_CODE_MESSAGE_MAP: list[tuple[str, str | None, type[BaseOverkizException]]] = [
+_ERROR_CODE_MESSAGE_MAP: list[tuple[str, str | None, type[BaseOverkizError]]] = [
     # --- errorCode is the sole discriminator ---
-    ("DUPLICATE_FIELD_OR_VALUE", None, DuplicateActionOnDeviceException),
-    ("INVALID_FIELD_VALUE", None, ActionGroupSetupNotFoundException),
-    ("INVALID_API_CALL", None, NoSuchResourceException),
-    ("EXEC_QUEUE_FULL", None, ExecutionQueueFullException),
+    ("DUPLICATE_FIELD_OR_VALUE", None, DuplicateActionOnDeviceError),
+    ("INVALID_FIELD_VALUE", None, ActionGroupSetupNotFoundError),
+    ("INVALID_API_CALL", None, NoSuchResourceError),
+    ("EXEC_QUEUE_FULL", None, ExecutionQueueFullError),
     # --- errorCode + message substring ---
-    ("AUTHENTICATION_ERROR", "Too many requests", TooManyRequestsException),
-    ("AUTHENTICATION_ERROR", "Bad credentials", BadCredentialsException),
-    ("AUTHENTICATION_ERROR", "API key is required", MissingAPIKeyException),
-    ("AUTHENTICATION_ERROR", "No such user account", UnknownUserException),
-    ("RESOURCE_ACCESS_DENIED", "Not authenticated", NotAuthenticatedException),
+    ("AUTHENTICATION_ERROR", "Too many requests", TooManyRequestsError),
+    ("AUTHENTICATION_ERROR", "Bad credentials", BadCredentialsError),
+    ("AUTHENTICATION_ERROR", "API key is required", MissingAPIKeyError),
+    ("AUTHENTICATION_ERROR", "No such user account", UnknownUserError),
+    ("RESOURCE_ACCESS_DENIED", "Not authenticated", NotAuthenticatedError),
     (
         "RESOURCE_ACCESS_DENIED",
         "Missing authorization token",
-        MissingAuthorizationTokenException,
+        MissingAuthorizationTokenError,
     ),
     (
         "RESOURCE_ACCESS_DENIED",
         "too many concurrent requests",
-        TooManyConcurrentRequestsException,
+        TooManyConcurrentRequestsError,
     ),
-    ("RESOURCE_ACCESS_DENIED", "Too many executions", TooManyExecutionsException),
+    ("RESOURCE_ACCESS_DENIED", "Too many executions", TooManyExecutionsError),
     (
         "RESOURCE_ACCESS_DENIED",
         "Access denied to gateway",
-        AccessDeniedToGatewayException,
+        AccessDeniedToGatewayError,
     ),
     (
         "RESOURCE_ACCESS_DENIED",
         "cannot be accessed through this application",
-        ApplicationNotAllowedException,
+        ApplicationNotAllowedError,
     ),
-    ("UNSUPPORTED_OPERATION", "No such command", InvalidCommandException),
+    ("UNSUPPORTED_OPERATION", "No such command", InvalidCommandError),
     (
         "UNSPECIFIED_ERROR",
         "Invalid event listener id",
-        InvalidEventListenerIdException,
+        InvalidEventListenerIdError,
     ),
     (
         "UNSPECIFIED_ERROR",
         "No registered event listener",
-        NoRegisteredEventListenerException,
+        NoRegisteredEventListenerError,
     ),
-    ("UNSPECIFIED_ERROR", "Unknown object", UnknownObjectException),
+    ("UNSPECIFIED_ERROR", "Unknown object", UnknownObjectError),
 ]
 
 # Message-only fallback patterns for responses where the errorCode alone is
 # not enough or may vary across API versions.
-_MESSAGE_FALLBACK_MAP: list[tuple[str, type[BaseOverkizException]]] = [
-    ("Too many executions", TooManyExecutionsException),
+_MESSAGE_FALLBACK_MAP: list[tuple[str, type[BaseOverkizError]]] = [
+    ("Too many executions", TooManyExecutionsError),
     (
         "Cannot use JSESSIONID and bearer token",
-        SessionAndBearerInSameRequestException,
+        SessionAndBearerInSameRequestError,
     ),
-    ("Too many attempts with an invalid token", TooManyAttemptsBannedException),
-    ("Invalid token", InvalidTokenException),
-    ("Not such token with UUID", NotSuchTokenException),
-    ("Unknown user", UnknownUserException),
-    ("No such command", InvalidCommandException),
-    ("No registered event listener", NoRegisteredEventListenerException),
-    ("Unknown object", UnknownObjectException),
-    ("Access denied to gateway", AccessDeniedToGatewayException),
+    ("Too many attempts with an invalid token", TooManyAttemptsBannedError),
+    ("Invalid token", InvalidTokenError),
+    ("Not such token with UUID", NoSuchTokenError),
+    ("Unknown user", UnknownUserError),
+    ("No such command", InvalidCommandError),
+    ("No registered event listener", NoRegisteredEventListenerError),
+    ("Unknown object", UnknownObjectError),
+    ("Access denied to gateway", AccessDeniedToGatewayError),
 ]
 
 # Fallback when errorCode is recognized but no message pattern matched.
-_ERROR_CODE_FALLBACK_MAP: dict[str, type[BaseOverkizException]] = {
-    "AUTHENTICATION_ERROR": BadCredentialsException,
-    "RESOURCE_ACCESS_DENIED": ResourceAccessDeniedException,
+_ERROR_CODE_FALLBACK_MAP: dict[str, type[BaseOverkizError]] = {
+    "AUTHENTICATION_ERROR": BadCredentialsError,
+    "RESOURCE_ACCESS_DENIED": ResourceAccessDeniedError,
 }
 
 
@@ -122,12 +122,12 @@ async def check_response(response: ClientResponse) -> None:
         result = await response.text()
 
         if "is down for maintenance" in result:
-            raise MaintenanceException("Server is down for maintenance") from error
+            raise MaintenanceError("Server is down for maintenance") from error
 
         if response.status == 503:
-            raise ServiceUnavailableException(result) from error
+            raise ServiceUnavailableError(result) from error
 
-        raise OverkizException(
+        raise OverkizError(
             f"Unknown error while requesting {response.url}. {response.status} - {result}"
         ) from error
 
@@ -154,5 +154,5 @@ async def check_response(response: ClientResponse) -> None:
         if error_code in _ERROR_CODE_FALLBACK_MAP:
             raise _ERROR_CODE_FALLBACK_MAP[error_code](message or str(result))
 
-    # Undefined Overkiz exception
-    raise OverkizException(result)
+    # Undefined Overkiz error
+    raise OverkizError(result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,8 @@ select = [
     "T",
     # flake8-comprehensions
     "C4",
+    # pep8-naming
+    "N",
 ]
 ignore = ["E501"] # Line too long
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -38,7 +38,7 @@ from pyoverkiz.auth.strategies import (
     _decode_jwt_payload,
 )
 from pyoverkiz.enums import APIType, Server
-from pyoverkiz.exceptions import InvalidTokenException, NexityBadCredentialsException
+from pyoverkiz.exceptions import InvalidTokenError, NexityBadCredentialsError
 from pyoverkiz.models import ServerConfig
 
 
@@ -493,7 +493,7 @@ class TestNexityAuthStrategy:
 
     @pytest.mark.asyncio
     async def test_login_maps_invalid_credentials_client_error(self):
-        """Map Cognito bad-credential errors to NexityBadCredentialsException."""
+        """Map Cognito bad-credential errors to NexityBadCredentialsError."""
         server_config = ServerConfig(
             server=Server.NEXITY,
             name="Nexity",
@@ -516,7 +516,7 @@ class TestNexityAuthStrategy:
             patch(
                 "pyoverkiz.auth.strategies.WarrantLite", return_value=warrant_instance
             ),
-            pytest.raises(NexityBadCredentialsException),
+            pytest.raises(NexityBadCredentialsError),
         ):
             strategy = NexityAuthStrategy(
                 credentials, session, server_config, True, APIType.CLOUD
@@ -561,7 +561,7 @@ class TestRexelAuthStrategy:
 
     @pytest.mark.asyncio
     async def test_exchange_token_error_response(self):
-        """Ensure OAuth error payloads raise InvalidTokenException before parsing access token."""
+        """Ensure OAuth error payloads raise InvalidTokenError before parsing access token."""
         server_config = ServerConfig(
             server=Server.REXEL,
             name="Rexel",
@@ -585,7 +585,7 @@ class TestRexelAuthStrategy:
             credentials, session, server_config, True, APIType.CLOUD
         )
 
-        with pytest.raises(InvalidTokenException, match="bad grant"):
+        with pytest.raises(InvalidTokenError, match="bad grant"):
             await strategy._exchange_token({"grant_type": "authorization_code"})
 
     def test_ensure_consent_missing(self):
@@ -597,10 +597,10 @@ class TestRexelAuthStrategy:
         )
         token = f"header.{payload_segment}.sig"
 
-        with pytest.raises(InvalidTokenException, match="Consent is missing"):
+        with pytest.raises(InvalidTokenError, match="Consent is missing"):
             RexelAuthStrategy._ensure_consent(token)
 
     def test_decode_jwt_payload_invalid_format(self):
-        """Malformed tokens raise InvalidTokenException during decoding."""
-        with pytest.raises(InvalidTokenException):
+        """Malformed tokens raise InvalidTokenError during decoding."""
+        with pytest.raises(InvalidTokenError):
             _decode_jwt_payload("invalid.token")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -120,7 +120,7 @@ class TestOverkizClient:
                 "_get",
                 new=AsyncMock(
                     side_effect=[
-                        exceptions.NotAuthenticatedException("expired"),
+                        exceptions.NotAuthenticatedError("expired"),
                         {"protocolVersion": "1"},
                     ]
                 ),
@@ -148,7 +148,7 @@ class TestOverkizClient:
                 "_post",
                 new=AsyncMock(
                     side_effect=[
-                        exceptions.InvalidEventListenerIdException("bad listener"),
+                        exceptions.InvalidEventListenerIdError("bad listener"),
                         [],
                     ]
                 ),
@@ -173,7 +173,7 @@ class TestOverkizClient:
                 "_post",
                 new=AsyncMock(
                     side_effect=[
-                        exceptions.TooManyConcurrentRequestsException("busy"),
+                        exceptions.TooManyConcurrentRequestsError("busy"),
                         {"id": "listener-3"},
                     ]
                 ),
@@ -367,177 +367,177 @@ class TestOverkizClient:
     @pytest.mark.parametrize(
         "fixture_name, exception, status_code",
         [
-            ("cloud/503-empty.html", exceptions.ServiceUnavailableException, 503),
-            ("cloud/503-maintenance.html", exceptions.MaintenanceException, 503),
+            ("cloud/503-empty.html", exceptions.ServiceUnavailableError, 503),
+            ("cloud/503-maintenance.html", exceptions.MaintenanceError, 503),
             (
                 "cloud/access-denied-to-gateway.json",
-                exceptions.AccessDeniedToGatewayException,
+                exceptions.AccessDeniedToGatewayError,
                 400,
             ),
             (
                 "cloud/application-not-allowed.json",
-                exceptions.ApplicationNotAllowedException,
+                exceptions.ApplicationNotAllowedError,
                 400,
             ),
             (
                 "cloud/bad-credentials.json",
-                exceptions.BadCredentialsException,
+                exceptions.BadCredentialsError,
                 400,
             ),
             (
                 "cloud/missing-authorization-token.json",
-                exceptions.MissingAuthorizationTokenException,
+                exceptions.MissingAuthorizationTokenError,
                 400,
             ),
             (
                 "cloud/no-registered-event-listener.json",
-                exceptions.NoRegisteredEventListenerException,
+                exceptions.NoRegisteredEventListenerError,
                 400,
             ),
             (
                 "cloud/too-many-concurrent-requests.json",
-                exceptions.TooManyConcurrentRequestsException,
+                exceptions.TooManyConcurrentRequestsError,
                 400,
             ),
             (
                 "cloud/too-many-executions.json",
-                exceptions.TooManyExecutionsException,
+                exceptions.TooManyExecutionsError,
                 400,
             ),
             (
                 "cloud/too-many-requests.json",
-                exceptions.TooManyRequestsException,
+                exceptions.TooManyRequestsError,
                 400,
             ),
             (
                 "cloud/no-such-resource.json",
-                exceptions.NoSuchResourceException,
+                exceptions.NoSuchResourceError,
                 400,
             ),
             (
                 "cloud/exec-queue-full.json",
-                exceptions.ExecutionQueueFullException,
+                exceptions.ExecutionQueueFullError,
                 400,
             ),
             (
                 "cloud/missing-api-key.json",
-                exceptions.MissingAPIKeyException,
+                exceptions.MissingAPIKeyError,
                 400,
             ),
             (
                 "cloud/unknown-user-account.json",
-                exceptions.UnknownUserException,
+                exceptions.UnknownUserError,
                 400,
             ),
             (
                 "cloud/no-such-command.json",
-                exceptions.InvalidCommandException,
+                exceptions.InvalidCommandError,
                 400,
             ),
             (
                 "cloud/invalid-event-listener-id.json",
-                exceptions.InvalidEventListenerIdException,
+                exceptions.InvalidEventListenerIdError,
                 400,
             ),
             (
                 "cloud/session-and-bearer.json",
-                exceptions.SessionAndBearerInSameRequestException,
+                exceptions.SessionAndBearerInSameRequestError,
                 400,
             ),
             (
                 "cloud/too-many-attempts-banned.json",
-                exceptions.TooManyAttemptsBannedException,
+                exceptions.TooManyAttemptsBannedError,
                 400,
             ),
             (
                 "cloud/invalid-token.json",
-                exceptions.InvalidTokenException,
+                exceptions.InvalidTokenError,
                 400,
             ),
             (
                 "cloud/not-such-token.json",
-                exceptions.NotSuchTokenException,
+                exceptions.NoSuchTokenError,
                 400,
             ),
             (
                 "cloud/unknown-auth-error.json",
-                exceptions.BadCredentialsException,
+                exceptions.BadCredentialsError,
                 400,
             ),
             (
                 "cloud/unknown-resource-access-denied.json",
-                exceptions.ResourceAccessDeniedException,
+                exceptions.ResourceAccessDeniedError,
                 400,
             ),
             # (
             #     "local/204-no-corresponding-execId.json",
-            #     exceptions.OverkizException,
+            #     exceptions.OverkizError,
             #     204,
             # ),
             (
                 "local/400-bad-parameters.json",
-                exceptions.OverkizException,
+                exceptions.OverkizError,
                 400,
             ),
-            ("local/400-bus-error.json", exceptions.OverkizException, 400),
+            ("local/400-bus-error.json", exceptions.OverkizError, 400),
             (
                 "local/400-malformed-action-group.json",
-                exceptions.OverkizException,
+                exceptions.OverkizError,
                 400,
             ),
             (
                 "local/400-malformed-fetch-id.json",
-                exceptions.OverkizException,
+                exceptions.OverkizError,
                 400,
             ),
             (
                 "local/400-missing-execution-id.json",
-                exceptions.OverkizException,
+                exceptions.OverkizError,
                 400,
             ),
             (
                 "local/400-missing-parameters.json",
-                exceptions.OverkizException,
+                exceptions.OverkizError,
                 400,
             ),
             (
                 "local/400-duplicate-action-on-device.json",
-                exceptions.DuplicateActionOnDeviceException,
+                exceptions.DuplicateActionOnDeviceError,
                 400,
             ),
             (
                 "local/400-action-group-setup-not-found.json",
-                exceptions.ActionGroupSetupNotFoundException,
+                exceptions.ActionGroupSetupNotFoundError,
                 400,
             ),
             (
                 "local/400-no-registered-event-listener.json",
-                exceptions.NoRegisteredEventListenerException,
+                exceptions.NoRegisteredEventListenerError,
                 400,
             ),
             (
                 "local/400-no-such-device.json",
-                exceptions.OverkizException,
+                exceptions.OverkizError,
                 400,
             ),
             (
                 "local/400-unknown-object.json",
-                exceptions.UnknownObjectException,
+                exceptions.UnknownObjectError,
                 400,
             ),
             (
                 "local/400-unspecified-error.json",
-                exceptions.OverkizException,
+                exceptions.OverkizError,
                 400,
             ),
             (
                 "local/401-missing-authorization-token.json",
-                exceptions.MissingAuthorizationTokenException,
+                exceptions.MissingAuthorizationTokenError,
                 401,
             ),
             (
                 "local/401-not-authenticated.json",
-                exceptions.NotAuthenticatedException,
+                exceptions.NotAuthenticatedError,
                 401,
             ),
         ],
@@ -549,7 +549,7 @@ class TestOverkizClient:
         status_code: int,
         exception: Exception,
     ):
-        """Ensure client raises the correct exception for various error fixtures/status codes."""
+        """Ensure client raises the correct error for various error fixtures/status codes."""
         with pytest.raises(exception):
             if fixture_name:
                 with open(

--- a/utils/generate_enums.py
+++ b/utils/generate_enums.py
@@ -17,7 +17,7 @@ from typing import cast
 from pyoverkiz.auth.credentials import UsernamePasswordCredentials
 from pyoverkiz.client import OverkizClient
 from pyoverkiz.enums import Server
-from pyoverkiz.exceptions import OverkizException
+from pyoverkiz.exceptions import OverkizError
 from pyoverkiz.models import UIProfileDefinition, ValuePrototype
 
 # Hardcoded protocols that may not be available on all servers
@@ -271,7 +271,7 @@ async def generate_ui_profiles(server: Server) -> None:
             try:
                 details = await client.get_reference_ui_profile(profile_name)
                 profiles_with_details.append((profile_name, details))
-            except OverkizException:
+            except OverkizError:
                 print(f"  ! Could not fetch details for {profile_name}")
                 profiles_with_details.append((profile_name, None))
 


### PR DESCRIPTION
Rename all custom exception classes to use the Error suffix per PEP 8 naming conventions (ruff N818). Also fix typo NotSuchTokenException to NoSuchTokenError. Enable pep8-naming (N) ruff rules.

## Breaking
All custom exception classes have been renamed from *Exception to *Error to follow PEP 8 naming conventions (e.g. NotAuthenticatedException → NotAuthenticatedError). Additionally, NotSuchTokenException has been fixed to NoSuchTokenError (typo fix).