### PR TITLE
Rename ServerConfig.type to api_type

### DIFF
--- a/pyoverkiz/auth/factory.py
+++ b/pyoverkiz/auth/factory.py
@@ -43,7 +43,7 @@ def build_auth_strategy(
             session,
             server_config,
             ssl_context,
-            server_config.type,
+            server_config.api_type,
         )
 
     if server in {
@@ -56,7 +56,7 @@ def build_auth_strategy(
             session,
             server_config,
             ssl_context,
-            server_config.type,
+            server_config.api_type,
         )
 
     if server == Server.NEXITY:
@@ -65,7 +65,7 @@ def build_auth_strategy(
             session,
             server_config,
             ssl_context,
-            server_config.type,
+            server_config.api_type,
         )
 
     if server == Server.REXEL:
@@ -74,27 +74,27 @@ def build_auth_strategy(
             session,
             server_config,
             ssl_context,
-            server_config.type,
+            server_config.api_type,
         )
 
-    if server_config.type == APIType.LOCAL:
+    if server_config.api_type == APIType.LOCAL:
         if isinstance(credentials, LocalTokenCredentials):
             return LocalTokenAuthStrategy(
-                credentials, session, server_config, ssl_context, server_config.type
+                credentials, session, server_config, ssl_context, server_config.api_type
             )
         return BearerTokenAuthStrategy(
             _ensure_token(credentials),
             session,
             server_config,
             ssl_context,
-            server_config.type,
+            server_config.api_type,
         )
 
     if isinstance(credentials, TokenCredentials) and not isinstance(
         credentials, LocalTokenCredentials
     ):
         return BearerTokenAuthStrategy(
-            credentials, session, server_config, ssl_context, server_config.type
+            credentials, session, server_config, ssl_context, server_config.api_type
         )
 
     return SessionLoginStrategy(
@@ -102,7 +102,7 @@ def build_auth_strategy(
         session,
         server_config,
         ssl_context,
-        server_config.type,
+        server_config.api_type,
     )
 
 

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -187,7 +187,7 @@ class OverkizClient:
         )
         self._ssl = verify_ssl
 
-        if self.server_config.type == APIType.LOCAL and verify_ssl:
+        if self.server_config.api_type == APIType.LOCAL and verify_ssl:
             # Use the prebuilt SSL context with disabled strict validation for local API.
             self._ssl = SSL_CONTEXT_LOCAL_API
 
@@ -268,7 +268,7 @@ class OverkizClient:
         """
         await self._auth.login()
 
-        if self.server_config.type == APIType.LOCAL:
+        if self.server_config.api_type == APIType.LOCAL:
             if register_event_listener:
                 await self.register_event_listener()
             else:

--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -1180,7 +1180,7 @@ class ServerConfig:
     name: str
     endpoint: str
     manufacturer: str
-    type: APIType
+    api_type: APIType
     configuration_url: str | None = None
 
     def __init__(
@@ -1201,7 +1201,7 @@ class ServerConfig:
         self.name = name
         self.endpoint = endpoint
         self.manufacturer = manufacturer
-        self.type = api_type if isinstance(api_type, APIType) else APIType(api_type)
+        self.api_type = api_type if isinstance(api_type, APIType) else APIType(api_type)
         self.configuration_url = configuration_url
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -50,12 +50,12 @@ class TestOverkizClient:
     @pytest.mark.asyncio
     async def test_get_api_type_cloud(self, client: OverkizClient):
         """Verify that a cloud-configured client reports APIType.CLOUD."""
-        assert client.server_config.type == APIType.CLOUD
+        assert client.server_config.api_type == APIType.CLOUD
 
     @pytest.mark.asyncio
     async def test_get_api_type_local(self, local_client: OverkizClient):
         """Verify that a local-configured client reports APIType.LOCAL."""
-        assert local_client.server_config.type == APIType.LOCAL
+        assert local_client.server_config.api_type == APIType.LOCAL
 
     @pytest.mark.asyncio
     async def test_get_devices_basic(self, client: OverkizClient):


### PR DESCRIPTION
## Summary

- Rename `ServerConfig.type` to `ServerConfig.api_type` to avoid shadowing the Python builtin `type`
- Update all references in `client.py`, `auth/factory.py`, and tests

## Test plan
- [x] All 280 tests pass
- [x] ruff, mypy, ty all pass