### PR TITLE
Enable additional ruff lint rules (zero-violation batch)

### DIFF
--- a/pyoverkiz/action_queue.py
+++ b/pyoverkiz/action_queue.py
@@ -284,7 +284,7 @@ class ActionQueue:
             for waiter in waiters:
                 waiter.set_exception(exc)
             raise
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             # Propagate exceptions to all waiters without swallowing system-level exits.
             for waiter in waiters:
                 waiter.set_exception(exc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ select = [
     "ASYNC",
     # pycodestyle
     "E",
+    "W",
     # Pyflakes
     "F",
     # pyupgrade
@@ -75,6 +76,14 @@ select = [
     "N",
     # flake8-pytest-style
     "PT",
+    # flake8-logging
+    "LOG",
+    # flake8-datetimez
+    "DTZ",
+    # flynt
+    "FLY",
+    # flake8-implicit-str-concat
+    "ISC",
 ]
 ignore = ["E501"] # Line too long
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,11 +84,35 @@ select = [
     "FLY",
     # flake8-implicit-str-concat
     "ISC",
+    # pygrep-hooks
+    "PGH",
+    # flake8-self
+    "SLF",
+    # flake8-slots
+    "SLOT",
+    # tidy imports
+    "TID",
+    # flake8-no-pep420
+    "INP",
+    # import conventions
+    "ICN",
+    # flake8-logging-format
+    "G",
+    # blind exception
+    "BLE",
+    # tryceratops
+    "TRY",
+    # flake8-quotes
+    "Q",
 ]
-ignore = ["E501"] # Line too long
+ignore = [
+    "E501",    # Line too long
+    "TRY003",  # Long exception messages are acceptable for domain-specific errors
+]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["S101"]  # Allow assert in tests
+"tests/**" = ["S101", "SLF001"]  # Allow assert and private member access in tests
+"utils/**" = ["INP001", "BLE001"]  # Utils are scripts, not packages
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"  # Accepts: "google", "numpy", or "pep257".


### PR DESCRIPTION
## Summary
- Add 15 new ruff rule sets that require no code changes: W, LOG, DTZ, FLY, ISC, PGH, SLF, SLOT, TID, INP, ICN, G, BLE, TRY, Q
- Ignore TRY003 globally (long exception messages are idiomatic for domain-specific errors)
- Add per-file ignores for tests (SLF001) and utils (INP001, BLE001)
- Add noqa for intentional blind except in ActionQueue worker

## Test plan
- [x] `ruff check .` passes
- [x] `pytest` — 280 tests pass
- [x] `mypy` passes