### PR TITLE
Enable ruff PT rules (pytest style)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,8 @@ select = [
     "C4",
     # pep8-naming
     "N",
+    # flake8-pytest-style
+    "PT",
 ]
 ignore = ["E501"] # Line too long
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -523,10 +523,10 @@ class TestNexityAuthStrategy:
         with (
             patch("boto3.client", return_value=MagicMock()),
             patch("warrant_lite.WarrantLite", return_value=warrant_instance),
-            pytest.raises(NexityBadCredentialsError),
         ):
             strategy = NexityAuthStrategy(credentials, session, server_config, True)
-            await strategy.login()
+            with pytest.raises(NexityBadCredentialsError):
+                await strategy.login()
 
     @pytest.mark.asyncio
     async def test_login_propagates_non_auth_client_error(self):
@@ -551,10 +551,10 @@ class TestNexityAuthStrategy:
         with (
             patch("boto3.client", return_value=MagicMock()),
             patch("warrant_lite.WarrantLite", return_value=warrant_instance),
-            pytest.raises(ClientError, match="InternalErrorException"),
         ):
             strategy = NexityAuthStrategy(credentials, session, server_config, True)
-            await strategy.login()
+            with pytest.raises(ClientError, match="InternalErrorException"):
+                await strategy.login()
 
 
 class TestRexelAuthStrategy:

--- a/tests/test_case.py
+++ b/tests/test_case.py
@@ -48,7 +48,7 @@ class TestDecamelize:
         assert decamelize({"nparams": 0}) == {"nparams": 0}
 
     @pytest.mark.parametrize(
-        "camel, expected",
+        ("camel", "expected"),
         [
             ("deviceURL", "device_url"),
             ("placeOID", "place_oid"),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -70,7 +70,7 @@ class TestOverkizClient:
             assert len(devices) == 23
 
     @pytest.mark.parametrize(
-        "fixture_name, event_length",
+        ("fixture_name", "event_length"),
         [
             ("events.json", 16),
             ("local_events.json", 3),
@@ -228,7 +228,7 @@ class TestOverkizClient:
                         assert isinstance(state.value, dict)
 
     @pytest.mark.parametrize(
-        "fixture_name, device_count, gateway_count",
+        ("fixture_name", "device_count", "gateway_count"),
         [
             ("setup_3_gateways.json", 37, 3),
             ("setup_cozytouch.json", 12, 1),
@@ -365,7 +365,7 @@ class TestOverkizClient:
             obfuscate.assert_not_called()
 
     @pytest.mark.parametrize(
-        "fixture_name, exception, status_code",
+        ("fixture_name", "exception", "status_code"),
         [
             ("cloud/503-empty.html", exceptions.ServiceUnavailableError, 503),
             ("cloud/503-maintenance.html", exceptions.MaintenanceError, 503),
@@ -550,16 +550,16 @@ class TestOverkizClient:
         exception: Exception,
     ):
         """Ensure client raises the correct error for various error fixtures/status codes."""
-        with pytest.raises(exception):
-            if fixture_name:
-                with open(
-                    os.path.join(CURRENT_DIR, "fixtures/exceptions/" + fixture_name),
-                    encoding="utf-8",
-                ) as raw_events:
-                    resp = MockResponse(raw_events.read(), status_code)
-            else:
-                resp = MockResponse(None, status_code)
+        if fixture_name:
+            with open(
+                os.path.join(CURRENT_DIR, "fixtures/exceptions/" + fixture_name),
+                encoding="utf-8",
+            ) as raw_events:
+                resp = MockResponse(raw_events.read(), status_code)
+        else:
+            resp = MockResponse(None, status_code)
 
+        with pytest.raises(exception):
             await check_response(resp)
 
     @pytest.mark.asyncio
@@ -651,7 +651,7 @@ class TestOverkizClient:
             assert cmd["name"] == "close"
 
     @pytest.mark.parametrize(
-        "fixture_name, option_name, instance",
+        ("fixture_name", "option_name", "instance"),
         [
             (
                 "setup-options-developerMode.json",
@@ -685,7 +685,7 @@ class TestOverkizClient:
                 assert isinstance(option, instance)
 
     @pytest.mark.parametrize(
-        "fixture_name, scenario_count",
+        ("fixture_name", "scenario_count"),
         [
             ("action-group-cozytouch.json", 9),
             ("action-group-tahoma-box-v1.json", 17),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -115,7 +115,14 @@ class TestDevice:
     """Tests for Device model parsing and property extraction."""
 
     @pytest.mark.parametrize(
-        "device_url, protocol, gateway_id, device_address, subsystem_id, is_sub_device",
+        (
+            "device_url",
+            "protocol",
+            "gateway_id",
+            "device_address",
+            "subsystem_id",
+            "is_sub_device",
+        ),
         [
             (
                 "io://1234-5678-9012/10077486",

--- a/tests/test_obfuscate.py
+++ b/tests/test_obfuscate.py
@@ -12,7 +12,7 @@ class TestObfucscate:
     """Tests for obfuscation utilities (emails and sensitive data)."""
 
     @pytest.mark.parametrize(
-        "email, obfuscated",
+        ("email", "obfuscated"),
         [
             ("contact@somfy.com", "c****@****y.com"),
             ("contact_-_nexity.com", "c****@****y.com"),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,7 +43,7 @@ class TestUtils:
         assert local_server.configuration_url == "https://somfy.com"
 
     @pytest.mark.parametrize(
-        "gateway_id, overkiz_gateway",
+        ("gateway_id", "overkiz_gateway"),
         [
             ("1234-5678-6968", True),
             ("SOMFY_PROTECT-v0NT53occUBPyuJRzx59kalW1hFfzimN", False),


### PR DESCRIPTION
## Summary
- Use tuples for `pytest.mark.parametrize` argument names (PT006)
- Narrow `pytest.raises` blocks to contain only the raising statement (PT012)

## Test plan
- [x] `ruff check .` passes
- [x] `pytest` — 280 tests pass