### PR TITLE
Enable ruff FURB, PERF, RSE, RET, PIE rules

### DIFF
--- a/pyoverkiz/auth/strategies.py
+++ b/pyoverkiz/auth/strategies.py
@@ -66,7 +66,7 @@ class BaseAuthStrategy(AuthStrategy):
 
     async def login(self) -> None:
         """Perform authentication; default is a no-op for subclasses to override."""
-        return None
+        return
 
     async def refresh_if_needed(self) -> bool:
         """Refresh authentication tokens if needed; default returns False."""
@@ -78,7 +78,7 @@ class BaseAuthStrategy(AuthStrategy):
 
     async def close(self) -> None:
         """Close any resources held by the strategy; default is no-op."""
-        return None
+        return
 
 
 class SessionLoginStrategy(BaseAuthStrategy):
@@ -269,7 +269,7 @@ class NexityAuthStrategy(SessionLoginStrategy):
         except ClientError as error:
             code = error.response.get("Error", {}).get("Code")
             if code in {"NotAuthorizedException", "UserNotFoundException"}:
-                raise NexityBadCredentialsError() from error
+                raise NexityBadCredentialsError from error
             raise
 
         id_token = tokens["AuthenticationResult"]["IdToken"]

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -180,10 +180,8 @@ class OverkizClient:
         self.gateways: list[Gateway] = []
         self.event_listener_id: str | None = None
 
-        self.session = (
-            session
-            if session
-            else ClientSession(headers={"User-Agent": "python-overkiz-api"})
+        self.session = session or ClientSession(
+            headers={"User-Agent": "python-overkiz-api"}
         )
         self._ssl = verify_ssl
 
@@ -519,8 +517,7 @@ class OverkizClient:
         if self._action_queue:
             queued = await self._action_queue.add(actions, mode, label)
             return await queued
-        else:
-            return await self._execute_action_group_direct(actions, mode, label)
+        return await self._execute_action_group_direct(actions, mode, label)
 
     async def flush_action_queue(self) -> None:
         """Force flush all pending actions in the queue immediately.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,16 @@ select = [
     "TRY",
     # flake8-quotes
     "Q",
+    # refurb
+    "FURB",
+    # perflint
+    "PERF",
+    # flake8-raise
+    "RSE",
+    # flake8-return
+    "RET",
+    # flake8-pie
+    "PIE",
 ]
 ignore = [
     "E501",    # Line too long

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -745,7 +745,6 @@ class MockResponse:
 
     async def __aexit__(self, exc_type, exc, tb):
         """Context manager exit (noop)."""
-        pass
 
     async def __aenter__(self):
         """Context manager enter returning self."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -218,7 +218,7 @@ class TestDevice:
         """Ensure device URL parsing extracts protocol, gateway and address correctly."""
         test_device = {
             **RAW_DEVICES,
-            **{"deviceURL": device_url},
+            "deviceURL": device_url,
         }
         device_data = decamelize(test_device)
         device = Device(**device_data)
@@ -240,7 +240,7 @@ class TestDevice:
         """Invalid device URLs should raise during identifier parsing."""
         test_device = {
             **RAW_DEVICES,
-            **{"deviceURL": device_url},
+            "deviceURL": device_url,
         }
         device_data = decamelize(test_device)
 

--- a/utils/generate_enums.py
+++ b/utils/generate_enums.py
@@ -363,12 +363,11 @@ async def generate_ui_profiles(server: Server) -> None:
 
                     # Get parameter info
                     if cmd.prototype and cmd.prototype.parameters:
-                        param_strs = []
-                        for param in cmd.prototype.parameters:
-                            if param.value_prototypes:
-                                param_strs.append(
-                                    format_value_prototype(param.value_prototypes[0])
-                                )
+                        param_strs = [
+                            format_value_prototype(param.value_prototypes[0])
+                            for param in cmd.prototype.parameters
+                            if param.value_prototypes
+                        ]
                         param_info = (
                             f"({', '.join(param_strs)})" if param_strs else "()"
                         )


### PR DESCRIPTION
## Summary
- Replace ternary with `or` operator (FURB110)
- Use list comprehension instead of append loop (PERF401)
- Remove unnecessary parentheses on raise (RSE102)
- Remove explicit `return None` and unnecessary `else` after `return` (RET)
- Remove unnecessary `pass` and dict spread (PIE)

## Test plan
- [x] `ruff check .` passes
- [x] `pytest` — 280 tests pass