### PR TITLE
Enable ruff PYI rule (type annotation improvements)

### DIFF
--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -7,7 +7,7 @@ import ssl
 import urllib.parse
 from pathlib import Path
 from types import TracebackType
-from typing import Any, cast
+from typing import Any, Self, cast
 
 import backoff
 from aiohttp import (
@@ -216,7 +216,7 @@ class OverkizClient:
             ssl_context=self._ssl,
         )
 
-    async def __aenter__(self) -> OverkizClient:
+    async def __aenter__(self) -> Self:
         """Enter async context manager and return the client instance."""
         return self
 

--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -1265,8 +1265,8 @@ class ValuePrototype:
     """Value prototype defining parameter/state value constraints."""
 
     type: str
-    min_value: int | float | None = None
-    max_value: int | float | None = None
+    min_value: float | None = None
+    max_value: float | None = None
     enum_values: list[str] | None = None
     description: str | None = None
 

--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -1273,8 +1273,8 @@ class ValuePrototype:
     def __init__(
         self,
         type: str,
-        min_value: int | float | None = None,
-        max_value: int | float | None = None,
+        min_value: float | None = None,
+        max_value: float | None = None,
         enum_values: list[str] | None = None,
         description: str | None = None,
         **_: Any,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,8 @@ select = [
     "PIE",
     # eradicate
     "ERA",
+    # flake8-pyi
+    "PYI",
 ]
 ignore = [
     "E501",    # Line too long


### PR DESCRIPTION
## Summary
- Use `Self` return type for `__aenter__` (PYI034)
- Simplify `int | float` to `float` in type hints (PYI041)

## Test plan
- [x] `ruff check .` passes
- [x] `pytest` — 280 tests pass
- [x] `mypy` passes