### PR TITLE
Enable ruff A rule (builtin shadowing detection)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,10 +120,13 @@ select = [
     "PYI",
     # flake8-pathlib
     "PTH",
+    # flake8-builtins
+    "A",
 ]
 ignore = [
     "E501",    # Line too long
     "TRY003",  # Long exception messages are acceptable for domain-specific errors
+    "A002",    # Shadowing builtins (id, type) is intentional for API field names
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/test_obfuscate.py
+++ b/tests/test_obfuscate.py
@@ -28,7 +28,7 @@ class TestObfucscateSensitive:
 
     def test_obfuscate_list_with_none(self):
         """Ensure lists containing None values are handled without modification."""
-        input = {
+        data = {
             "d": [
                 0,
                 0,
@@ -56,4 +56,4 @@ class TestObfucscateSensitive:
                 None,
             ]
         }
-        assert obfuscate_sensitive_data(input) == input
+        assert obfuscate_sensitive_data(data) == data


### PR DESCRIPTION
## Summary
- Add flake8-builtins rule set with A002 globally ignored (model parameters like `id`, `type` intentionally match Overkiz API field names)
- Rename shadowed `input` variable in `test_obfuscate.py`

## Test plan
- [x] `ruff check .` passes
- [x] `pytest` — 280 tests pass