### PR TITLE
Add PEP 740 provenance attestations to PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing via PyPi
       id-token: write
       contents: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@v6
@@ -55,5 +56,6 @@ jobs:
             uv build
 
       - name: Publish package to PyPI
-        run: |
-            uv publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true


### PR DESCRIPTION
## Summary
- Switch from `uv publish` to `pypa/gh-action-pypi-publish` with attestations enabled
- Add `attestations: write` permission to the release workflow
- Published packages will now include cryptographic provenance (Sigstore) linking them to this GitHub Actions workflow

## Context
[PEP 740](https://peps.python.org/pep-0740/) enables PyPI to display verified provenance for packages, proving they were built by the claimed CI pipeline. This uses the existing trusted publisher (OIDC) setup.

## Test plan
- [x] Verify trusted publisher is configured at https://pypi.org/manage/project/pyoverkiz/settings/publishing/
- [x] Publish a release and confirm attestation appears on PyPI