### PR TITLE
Add StateDefinitionType enum with convenience properties

### DIFF
--- a/pyoverkiz/enums/general.py
+++ b/pyoverkiz/enums/general.py
@@ -50,6 +50,22 @@ class DataType(IntEnum):
 
 
 @unique
+class StateDefinitionType(StrEnum):
+    """Type of a state definition describing its value semantics."""
+
+    CONTINUOUS = "ContinuousState"
+    DISCRETE = "DiscreteState"
+    DATA = "DataState"
+
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, value):  # type: ignore
+        _LOGGER.warning(f"Unsupported value {value} has been returned for {cls}")
+        return cls.UNKNOWN
+
+
+@unique
 class FailureType(IntEnum):
     """Failure type codes returned by the API."""
 

--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -18,6 +18,7 @@ from pyoverkiz.enums import (
     GatewaySubType,
     GatewayType,
     ProductType,
+    StateDefinitionType,
     UIClass,
     UIWidget,
     UpdateBoxStatus,
@@ -236,7 +237,7 @@ class StateDefinition:
     """Definition metadata for a state (qualified name, type and possible values)."""
 
     qualified_name: str
-    type: str | None = None
+    type: StateDefinitionType | None = None
     values: list[str] | None = None
 
     def __init__(
@@ -248,13 +249,28 @@ class StateDefinition:
         **_: Any,
     ) -> None:
         """Initialize StateDefinition and set qualified name from either `name` or `qualified_name`."""
-        self.type = type
+        self.type = StateDefinitionType(type) if type else None
         self.values = values
 
         if qualified_name:
             self.qualified_name = qualified_name
         elif name:
             self.qualified_name = name
+
+    @property
+    def is_continuous(self) -> bool:
+        """Return True if this state holds a continuous (numeric) value."""
+        return self.type == StateDefinitionType.CONTINUOUS
+
+    @property
+    def is_discrete(self) -> bool:
+        """Return True if this state holds one of a fixed set of string values."""
+        return self.type == StateDefinitionType.DISCRETE
+
+    @property
+    def is_data(self) -> bool:
+        """Return True if this state holds structured/opaque data."""
+        return self.type == StateDefinitionType.DATA
 
 
 @define(init=False, kw_only=True)

--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -257,21 +257,6 @@ class StateDefinition:
         elif name:
             self.qualified_name = name
 
-    @property
-    def is_continuous(self) -> bool:
-        """Return True if this state holds a continuous (numeric) value."""
-        return self.type == StateDefinitionType.CONTINUOUS
-
-    @property
-    def is_discrete(self) -> bool:
-        """Return True if this state holds one of a fixed set of string values."""
-        return self.type == StateDefinitionType.DISCRETE
-
-    @property
-    def is_data(self) -> bool:
-        """Return True if this state holds structured/opaque data."""
-        return self.type == StateDefinitionType.DATA
-
 
 @define(init=False, kw_only=True)
 class Definition:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 import humps
 import pytest
 
-from pyoverkiz.enums import DataType, Protocol
-from pyoverkiz.models import Device, State, States
+from pyoverkiz.enums import DataType, Protocol, StateDefinitionType
+from pyoverkiz.models import Device, State, StateDefinition, States
 
 RAW_STATES = [
     {"name": "core:NameState", "type": 3, "value": "alarm name"},
@@ -303,3 +303,70 @@ class TestState:
         state = State(name="state", type=DataType.BOOLEAN, value=False)
         with pytest.raises(TypeError):
             assert state.value_as_list
+
+
+class TestStateDefinition:
+    """Tests for StateDefinition type enum and convenience properties."""
+
+    def test_continuous_type(self):
+        """ContinuousState should be parsed as StateDefinitionType.CONTINUOUS."""
+        sd = StateDefinition(qualified_name="core:ClosureState", type="ContinuousState")
+        assert sd.type == StateDefinitionType.CONTINUOUS
+        assert sd.is_continuous
+        assert not sd.is_discrete
+        assert not sd.is_data
+
+    def test_discrete_type(self):
+        """DiscreteState should be parsed as StateDefinitionType.DISCRETE."""
+        sd = StateDefinition(
+            qualified_name="core:OnOffState",
+            type="DiscreteState",
+            values=["on", "off"],
+        )
+        assert sd.type == StateDefinitionType.DISCRETE
+        assert sd.is_discrete
+        assert not sd.is_continuous
+        assert not sd.is_data
+        assert sd.values == ["on", "off"]
+
+    def test_data_type(self):
+        """DataState should be parsed as StateDefinitionType.DATA."""
+        sd = StateDefinition(qualified_name="core:SomeDataState", type="DataState")
+        assert sd.type == StateDefinitionType.DATA
+        assert sd.is_data
+        assert not sd.is_continuous
+        assert not sd.is_discrete
+
+    def test_none_type(self):
+        """Missing type should result in None and all properties False."""
+        sd = StateDefinition(qualified_name="core:SomeState")
+        assert sd.type is None
+        assert not sd.is_continuous
+        assert not sd.is_discrete
+        assert not sd.is_data
+
+    def test_unknown_type(self):
+        """Unknown type strings should fallback to UNKNOWN."""
+        sd = StateDefinition(qualified_name="core:SomeState", type="FutureState")
+        assert sd.type == StateDefinitionType.UNKNOWN
+        assert not sd.is_continuous
+        assert not sd.is_discrete
+        assert not sd.is_data
+
+    def test_from_device_fixture(self):
+        """StateDefinitions in device fixture should be typed correctly."""
+        device = Device(**humps.decamelize(RAW_DEVICES))
+        closure = next(
+            sd
+            for sd in device.definition.states
+            if sd.qualified_name == "core:ClosureState"
+        )
+        assert closure.is_continuous
+
+        rssi = next(
+            sd
+            for sd in device.definition.states
+            if sd.qualified_name == "core:DiscreteRSSILevelState"
+        )
+        assert rssi.is_discrete
+        assert rssi.values == ["good", "low", "normal", "verylow"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -306,15 +306,12 @@ class TestState:
 
 
 class TestStateDefinition:
-    """Tests for StateDefinition type enum and convenience properties."""
+    """Tests for StateDefinition type enum parsing."""
 
     def test_continuous_type(self):
         """ContinuousState should be parsed as StateDefinitionType.CONTINUOUS."""
         sd = StateDefinition(qualified_name="core:ClosureState", type="ContinuousState")
         assert sd.type == StateDefinitionType.CONTINUOUS
-        assert sd.is_continuous
-        assert not sd.is_discrete
-        assert not sd.is_data
 
     def test_discrete_type(self):
         """DiscreteState should be parsed as StateDefinitionType.DISCRETE."""
@@ -324,34 +321,22 @@ class TestStateDefinition:
             values=["on", "off"],
         )
         assert sd.type == StateDefinitionType.DISCRETE
-        assert sd.is_discrete
-        assert not sd.is_continuous
-        assert not sd.is_data
         assert sd.values == ["on", "off"]
 
     def test_data_type(self):
         """DataState should be parsed as StateDefinitionType.DATA."""
         sd = StateDefinition(qualified_name="core:SomeDataState", type="DataState")
         assert sd.type == StateDefinitionType.DATA
-        assert sd.is_data
-        assert not sd.is_continuous
-        assert not sd.is_discrete
 
     def test_none_type(self):
-        """Missing type should result in None and all properties False."""
+        """Missing type should result in None."""
         sd = StateDefinition(qualified_name="core:SomeState")
         assert sd.type is None
-        assert not sd.is_continuous
-        assert not sd.is_discrete
-        assert not sd.is_data
 
     def test_unknown_type(self):
         """Unknown type strings should fallback to UNKNOWN."""
         sd = StateDefinition(qualified_name="core:SomeState", type="FutureState")
         assert sd.type == StateDefinitionType.UNKNOWN
-        assert not sd.is_continuous
-        assert not sd.is_discrete
-        assert not sd.is_data
 
     def test_from_device_fixture(self):
         """StateDefinitions in device fixture should be typed correctly."""
@@ -361,12 +346,12 @@ class TestStateDefinition:
             for sd in device.definition.states
             if sd.qualified_name == "core:ClosureState"
         )
-        assert closure.is_continuous
+        assert closure.type == StateDefinitionType.CONTINUOUS
 
         rssi = next(
             sd
             for sd in device.definition.states
             if sd.qualified_name == "core:DiscreteRSSILevelState"
         )
-        assert rssi.is_discrete
+        assert rssi.type == StateDefinitionType.DISCRETE
         assert rssi.values == ["good", "low", "normal", "verylow"]

--- a/uv.lock
+++ b/uv.lock
@@ -1023,7 +1023,7 @@ wheels = [
 
 [[package]]
 name = "pyoverkiz"
-version = "1.20.3"
+version = "1.20.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Add `StateDefinitionType` enum (`CONTINUOUS`, `DISCRETE`, `DATA`) with `_missing_` fallback
- Parse `StateDefinition.type` as `StateDefinitionType` instead of raw string

The Overkiz API returns exactly 3 state definition types:
- **ContinuousState** — numeric values (temperature, closure percentage, etc.)
- **DiscreteState** — enumerated string values (always paired with a `values` list)
- **DataState** — structured/opaque data

This enables downstream consumers to auto-detect entity types:

```python
from pyoverkiz.enums import StateDefinitionType

for state_def in device.definition.states:
    if state_def.type == StateDefinitionType.CONTINUOUS:
        # Create a sensor/number entity
    elif state_def.type == StateDefinitionType.DISCRETE:
        # Create a select entity with state_def.values as options
```

## Test plan

- [x] All existing tests pass (141 total)
- [x] New tests for type parsing, unknown type fallback, and fixture integration
- [x] mypy and ruff pass
- [x] Verified against real fixture data (all 3 types present)