### PR TITLE
Add auto-generated UI Profiles documentation page

### DIFF
--- a/docs/ui-profiles.md
+++ b/docs/ui-profiles.md
@@ -1,0 +1,2427 @@
+---
+hide:
+  - toc
+---
+
+# UI Profiles
+
+UI profiles describe device capabilities through the commands they accept and the states they expose. Each device has one or more profiles that define what it can do.
+
+!!! note
+    This page is auto-generated from the Overkiz API. Run `uv run utils/generate_enums.py` to regenerate.
+
+**189 profiles** documented below.
+
+## AirFan
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setFanSpeedLevel` | `int` (0–100) | Set the device fan speed level (%)
+ |
+
+## AirFanMode
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setFanSpeedMode` | `string` — `low`, `high` | Set the device fan speed mode
+ |
+
+## AirOutputLevelSensor
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:AirOutputLevelState` | `int` (0–100) | Air output level (%) |
+
+## AirQuality
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:GlobalAirQualityState` | `string` — `bad`, `error`, `excellent`, `fair`, `good`, `poor` | Air quality status |
+
+## Alarm
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `arm` |  | Arm the system
+ |
+| `disarm` |  | Disarm the system
+ |
+
+## AmbientNoiseSensor
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:AmbientNoiseState` | `float` (≥ 0.0) | Ambient noise in dB(A) |
+
+## BasicCloseable
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+
+## BasicOpenClose
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+
+## BasicUpDown
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `down` |  | Move the device completely down
+ |
+| `up` |  | Move the device completely up
+ |
+
+## BatteryStatus
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:BatteryState` | `string` — `verylow`, `low`, `normal`, `full` | Device battery status |
+
+## CO2Concentration
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:CO2ConcentrationState` | `float` (≥ 0.0) | Current carbon dioxide concentration (ppm) |
+
+## COConcentration
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:COConcentrationState` | `float` (≥ 0.0) | Current carbon monoxide concentration (ppm) |
+
+## CODetection
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:CODetectionState` | `string` — `detected`, `notDetected` | Indicate if carbon monoxide level is too high |
+
+## CardReader
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:CardPositionState` | `string` — `inserted`, `removed` | Indicate if a security card or device was inserted or detected |
+
+## Closeable
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## CloseableBlind
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## CloseableCurtain
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## CloseableScreen
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## CloseableShutter
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## CloseableWindow
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## ContactAndVibrationDetector
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ContactState` | `string` — `open`, `closed` | Contact sensor is open or closed |
+| `core:VibrationState` | `string` — `detected`, `notDetected` | Indicate if strong vibrations are detected or not |
+
+## ContactDetector
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ContactState` | `string` — `open`, `closed` | Contact sensor is open or closed |
+
+## CoolingThermostat
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point)
+ |
+
+## Cyclic
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `cycle` |  | Do a cycle of supported motion kinematics or modes
+ |
+
+## CyclicGarageOpener
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `cycle` |  | Do a cycle of supported motion kinematics or modes
+ |
+
+## CyclicGateOpener
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `cycle` |  | Do a cycle of supported motion kinematics or modes
+ |
+
+## DHWTemperature
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:DHWTemperatureState` | `float` (-100.0–100.0) | Current water temperature (°C) |
+
+## DHWThermostat
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setTargetDHWTemperature` | `float` (38.0–60.0) | Set the new water temperature to reach for a Domestic Hot Water system
+ |
+
+## DHWThermostatTargetReader
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:TargetDHWTemperatureState` | `float` (38.0–60.0) | Domestic hot water target temperature (°C) |
+
+## DeployUndeploy
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `deploy` |  | Fully deploy the device
+ |
+| `undeploy` |  | Fully undeploy the device
+ |
+
+## DeployUndeployAwning
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `deploy` |  | Fully deploy the device
+ |
+| `undeploy` |  | Fully undeploy the device
+ |
+
+## Deployable
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed)
+ |
+
+## DeployableAwning
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed)
+ |
+
+## DeployableVerticalAwning
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed)
+ |
+
+## Dimmable
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setIntensity` | `int` (0–100) | Light intensity level (100%=maximum intensity, 0%=off)
+ |
+
+## DoorContactSensor
+
+*Form factor specific* — tied to a specific physical device type.
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ContactState` | `string` — `open`, `closed` | Contact sensor is open or closed |
+
+## DoorOpeningStatus
+
+*Form factor specific* — tied to a specific physical device type.
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+
+## DualThermostat
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point)
+ |
+| `setHeatingTargetTemperature` | `float` (7.0–35.0) | Set the heating target temperature (manual set point)
+ |
+
+## ElectricCurrentMeter
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ElectricCurrentState` | `float` (≥ 0.0) | Current electric current intensity (Amp) |
+
+## ElectricEnergyAndPower
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ElectricEnergyConsumptionState` | `int` (≥ 0) | Electric energy consumption index (Wh) |
+| `core:ElectricPowerConsumptionState` | `float` (≥ 0.0) | Current electric power (W) |
+
+## ElectricEnergyConsumption
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ElectricEnergyConsumptionState` | `int` (≥ 0) | Electric energy consumption index (Wh) |
+
+## ElectricPowerMeter
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ElectricPowerConsumptionState` | `float` (≥ 0.0) | Current electric power (W) |
+
+## FossilEnergyConsumption
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:FossilEnergyConsumptionState` | `int` (≥ 0) | Fossil energy consumption index (Wh) |
+
+## GasConsumption
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:GasConsumptionState` | `float` (≥ 0.0) | Gas consumption index (m^3) |
+
+## GasDetector
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:GasDetectionState` | `string` — `detected`, `notDetected` | Indicate if a gas leak is detected or not |
+
+## Generic
+
+*Details unavailable.*
+
+## HeatingLevel
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setHeatingLevel` | `string` — `comfort`, `eco` | Sets the device heating level mode
+ |
+
+## IntrusionDetector
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:IntrusionState` | `string` — `detected`, `notDetected` | Indicate if an intrusion was detected or not |
+
+## IntrusionEventDetector
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:IntrusionDetectedState` | `boolean` | Indicate each time an intrusion was detected |
+
+## LevelControl
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setLevel` | `int` (0–100) | Generic device working level (0-100%)
+Functional meaning depends on device
+ |
+
+## LightDimmer
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setIntensity` | `int` (0–100) | Light intensity level (100%=maximum intensity, 0%=off)
+ |
+
+## Lock
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `lock` |  | Lock the device
+ |
+| `unlock` |  | Unlock the device
+ |
+
+## LockStatus
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:LockedUnlockedState` | `string` — `locked`, `unlocked` | Indicate if the device is locked or unlocked |
+
+## LockableOpeningStatus
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:LockedUnlockedState` | `string` — `locked`, `unlocked` | Indicate if the device is locked or unlocked |
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+
+## LockableTiltableOpeningStatus
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:LockedUnlockedState` | `string` — `locked`, `unlocked` | Indicate if the device is locked or unlocked |
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+| `core:TiltedState` | `boolean` | Indicate if a device is titled or straight |
+
+## LockableTiltableWindowOpeningStatus
+
+*Form factor specific* — tied to a specific physical device type.
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:LockedUnlockedState` | `string` — `locked`, `unlocked` | Indicate if the device is locked or unlocked |
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+| `core:TiltedState` | `boolean` | Indicate if a device is titled or straight |
+
+## Luminance
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:LuminanceState` | `int` (≥ 0) | Current illuminance value (Lux) |
+
+## MusicPlayer
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `pause` |  | Pause current action
+ |
+| `play` |  | Play media
+ |
+| `setVolume` | `int` (0–100) | Set the device output volume
+ |
+
+## OccupancyDetector
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OccupancyState` | `string` — `personInside`, `noPersonInside` | Indicate if a person or motion was detected or not |
+
+## OnOffButton
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OnOffButtonState` | `string` — `on`, `off` | Position of an on/off switch |
+
+## OnOffStatus
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OnOffState` | `string` — `on`, `off` | Device on/off status |
+
+## OpenClose
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## OpenCloseBlind
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## OpenCloseCameraShutter
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+
+## OpenCloseCurtain
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## OpenCloseGarageOpener
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## OpenCloseGateOpener
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## OpenCloseScreen
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## OpenCloseShutter
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## OpenCloseShutterSwitch
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+
+## OpenCloseSlidingGateOpener
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## OpenCloseSwingingShutter
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## OpenCloseWindow
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## OpeningStatus
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+
+## OperatingModeHeating
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setOperatingMode` | `any` | Set an operating mode
+ |
+
+## OrientableAndCloseable
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosureAndOrientation` | `int` (0–100), `int` (0–100) | Set both the closure level (0-100%) and relative slats orientation (0-100%) of the device
+ |
+
+## OrientableOrCloseable
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosureOrOrientation` | `int` (0–100), `int` (0–100) | Set device closure level (0-100%), or put the device in rocking position ('rocker') and set the relative slats orientation (0-100%) |
+
+## OrientablePlusCloseable
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## OrientableSlats
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
+ |
+
+## PictureCamera
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `takePicture` |  | Take a still picture
+ |
+
+## PowerCutDetector
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:PowerCutDetectionState` | `string` — `detected`, `notDetected` | Indicate if a main power cut was detected or not |
+
+## PushButtonSensor
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ButtonState` | `string` — `pressed`, `released`, `shortPressed` | Indicate if a button is pressed or released |
+
+## RainDetector
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:RainState` | `string` — `detected`, `notDetected` | Indicate if rain is detected or not |
+
+## RelativeHumidity
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:RelativeHumidityState` | `float` (0.0–100.0) | Air relative humidity (0%=totally dry, 100%=fully saturated) |
+
+## RockerSwitch
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:RockerSwitchPushWayState` | `string` — `heldDown`, `pressed`, `pressedX2`, `pressedX3`, `pressedX4`, `pressedX5`, `released` | Indicate when a rocker switch is pressed or released |
+
+## ScenarioTrigger
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:LaunchStatusState` | `string` — `launched`, `standby` | Indicates if the scene is launched or standby.
+"launched" value indicates that the launch conditions have been met (ex button pressed on a remote controller).
+"standby" value matches with an intermediate status, typically between two launch actions (ex button released on a remote controller).
+"launched" value should be used during a very short time and not persist across different launch events, whereas "standby" is a more stable value. |
+
+## Siren
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `ring` |  | Ask the device to start ringing
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## SlidingPergola
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed)
+ |
+
+## SmokeDetector
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:SmokeState` | `string` — `detected`, `notDetected` | Indicate if smoke is detected or not |
+
+## Specific
+
+*Details unavailable.*
+
+## StartStop
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `start` |  | Start the default actuator behavior (movement, sound or timer)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## StatefulAirFan
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setFanSpeedLevel` | `int` (0–100) | Set the device fan speed level (%)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:FanSpeedLevelState` | `int` (0–100) | Fan speed level (%) |
+
+## StatefulAlarm
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `arm` |  | Arm the system
+ |
+| `disarm` |  | Disarm the system
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ArmedState` | `boolean` | Indicate if the security device is armed (true=armed) |
+
+## StatefulBasicCloseable
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+
+## StatefulBasicOpenClose
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+
+## StatefulBioClimaticPergola
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:SlateOrientationState` | `int` (0–100) | Slats orientation percentage (0%=not tilted,100%=maximum tilt) |
+
+## StatefulCarLockWithOpeningStatus
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `lock` |  | Lock the device
+ |
+| `unlock` |  | Unlock the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:LockedUnlockedState` | `string` — `locked`, `unlocked` | Indicate if the device is locked or unlocked |
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+
+## StatefulCloseable
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+
+## StatefulCloseableAirVent
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+
+## StatefulCloseableBlind
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+
+## StatefulCloseableCurtain
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+
+## StatefulCloseableGarageOpener
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+
+## StatefulCloseableGateOpener
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+
+## StatefulCloseableScreen
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+
+## StatefulCloseableShutter
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+
+## StatefulCloseableSlidingDoor
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+
+## StatefulCloseableSlidingWindow
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+
+## StatefulCloseableSwingingShutter
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+
+## StatefulCloseableValve
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+
+## StatefulCloseableWindow
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+
+## StatefulCoolingThermostat
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:CoolingTargetTemperatureState` | `float` (12.0–30.0) | Room target temperature (°C) for dual heating/cooling system |
+
+## StatefulCoolingThermostatWithSensor
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:CoolingTargetTemperatureState` | `float` (12.0–30.0) | Room target temperature (°C) for dual heating/cooling system |
+| `core:TemperatureState` | `float` (-100.0–100.0) | Current room temperature (°C) |
+
+## StatefulDHWThermostat
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setTargetDHWTemperature` | `float` (38.0–60.0) | Set the new water temperature to reach for a Domestic Hot Water system
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:TargetDHWTemperatureState` | `float` (38.0–60.0) | Domestic hot water target temperature (°C) |
+
+## StatefulDeployUndeploy
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `deploy` |  | Fully deploy the device
+ |
+| `undeploy` |  | Fully undeploy the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:DeployedUndeployedState` | `string` — `deployed`, `undeployed` | Indicate if the device is deployed or not |
+
+## StatefulDeployUndeployAwning
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `deploy` |  | Fully deploy the device
+ |
+| `undeploy` |  | Fully undeploy the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:DeployedUndeployedState` | `string` — `deployed`, `undeployed` | Indicate if the device is deployed or not |
+
+## StatefulDeployable
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:DeploymentState` | `int` (0–100) | Device deployment percentage (0%=fully retracted, 100%=fully deployed) |
+
+## StatefulDeployableAwning
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:DeploymentState` | `int` (0–100) | Device deployment percentage (0%=fully retracted, 100%=fully deployed) |
+
+## StatefulDeployableVerticalAwning
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:DeploymentState` | `int` (0–100) | Device deployment percentage (0%=fully retracted, 100%=fully deployed) |
+
+## StatefulDimmable
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setIntensity` | `int` (0–100) | Light intensity level (100%=maximum intensity, 0%=off)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:LightIntensityState` | `int` (0–100) | Light intensity percentage (0%=min intensity,100%=maximum intensity) |
+
+## StatefulDoorLock
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `lock` |  | Lock the device
+ |
+| `unlock` |  | Unlock the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:LockedUnlockedState` | `string` — `locked`, `unlocked` | Indicate if the device is locked or unlocked |
+
+## StatefulDoorLockWithOpeningStatus
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `lock` |  | Lock the device
+ |
+| `unlock` |  | Unlock the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:LockedUnlockedState` | `string` — `locked`, `unlocked` | Indicate if the device is locked or unlocked |
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+
+## StatefulDualThermostat
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point)
+ |
+| `setHeatingTargetTemperature` | `float` (7.0–35.0) | Set the heating target temperature (manual set point)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:CoolingTargetTemperatureState` | `float` (12.0–30.0) | Room target temperature (°C) for dual heating/cooling system |
+| `core:HeatingTargetTemperatureState` | `float` (12.0–30.0) | Room target temperature (°C) for dual heating/cooling system |
+
+## StatefulDualThermostatWithSensor
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point)
+ |
+| `setHeatingTargetTemperature` | `float` (7.0–35.0) | Set the heating target temperature (manual set point)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:CoolingTargetTemperatureState` | `float` (12.0–30.0) | Room target temperature (°C) for dual heating/cooling system |
+| `core:HeatingTargetTemperatureState` | `float` (12.0–30.0) | Room target temperature (°C) for dual heating/cooling system |
+| `core:TemperatureState` | `float` (-100.0–100.0) | Current room temperature (°C) |
+
+## StatefulHeatingLevel
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setHeatingLevel` | `string` — `comfort`, `eco` | Sets the device heating level mode
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:TargetHeatingLevelState` | `string` — `comfort`, `eco` | Current heating level |
+
+## StatefulLevelControl
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setLevel` | `int` (0–100) | Generic device working level (0-100%)
+Functional meaning depends on device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:LevelState` | `int` (0–100) | Device working level percentage (0%=min level, 100%=maximum level) |
+
+## StatefulLevelControlHeating
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setLevel` | `int` (0–100) | Generic device working level (0-100%)
+Functional meaning depends on device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:LevelState` | `int` (0–100) | Device working level percentage (0%=min level, 100%=maximum level) |
+
+## StatefulLightDimmer
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setIntensity` | `int` (0–100) | Light intensity level (100%=maximum intensity, 0%=off)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:LightIntensityState` | `int` (0–100) | Light intensity percentage (0%=min intensity,100%=maximum intensity) |
+
+## StatefulLock
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `lock` |  | Lock the device
+ |
+| `unlock` |  | Unlock the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:LockedUnlockedState` | `string` — `locked`, `unlocked` | Indicate if the device is locked or unlocked |
+
+## StatefulLockWithOpeningStatus
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `lock` |  | Lock the device
+ |
+| `unlock` |  | Unlock the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:LockedUnlockedState` | `string` — `locked`, `unlocked` | Indicate if the device is locked or unlocked |
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+
+## StatefulOpenClose
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+
+## StatefulOpenCloseGateOpener
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+
+## StatefulOpenCloseShutter
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+
+## StatefulOpenCloseSwingingShutter
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+
+## StatefulOpenCloseValve
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `close` |  | Fully close the device
+ |
+| `open` |  | Fully open the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+
+## StatefulOperatingModeHeating
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setOperatingMode` | `any` | Set an operating mode
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OperatingModeState` | `string` — `antifreeze`, `auto`, `away`, `eco`, `frostprotection`, `manual`, `max`, `normal`, `off`, `on`, `prog`, `program`, `boost` | Current operating mode |
+
+## StatefulOrientableAndCloseable
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosureAndOrientation` | `int` (0–100), `int` (0–100) | Set both the closure level (0-100%) and relative slats orientation (0-100%) of the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+| `core:SlateOrientationState` | `int` (0–100) | Slats orientation percentage (0%=not tilted,100%=maximum tilt) |
+
+## StatefulOrientableAndCloseableShutter
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosureAndOrientation` | `int` (0–100), `int` (0–100) | Set both the closure level (0-100%) and relative slats orientation (0-100%) of the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+| `core:SlateOrientationState` | `int` (0–100) | Slats orientation percentage (0%=not tilted,100%=maximum tilt) |
+
+## StatefulOrientableOrCloseable
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosureOrOrientation` | `int` (0–100), `int` (0–100) | Set device closure level (0-100%), or put the device in rocking position ('rocker') and set the relative slats orientation (0-100%) |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+| `core:SlateOrientationState` | `int` (0–100) | Slats orientation percentage (0%=not tilted,100%=maximum tilt) |
+
+## StatefulOrientablePlusCloseable
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+| `core:SlateOrientationState` | `int` (0–100) | Slats orientation percentage (0%=not tilted,100%=maximum tilt) |
+
+## StatefulOrientablePlusCloseablePergola
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+| `core:SlateOrientationState` | `int` (0–100) | Slats orientation percentage (0%=not tilted,100%=maximum tilt) |
+
+## StatefulOrientableShutter
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
+ |
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+| `core:SlateOrientationState` | `int` (0–100) | Slats orientation percentage (0%=not tilted,100%=maximum tilt) |
+
+## StatefulOrientableSlats
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:SlateOrientationState` | `int` (0–100) | Slats orientation percentage (0%=not tilted,100%=maximum tilt) |
+
+## StatefulRockingShutter
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosureOrOrientation` | `int` (0–100), `int` (0–100) | Set device closure level (0-100%), or put the device in rocking position ('rocker') and set the relative slats orientation (0-100%) |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+| `core:SlateOrientationState` | `int` (0–100) | Slats orientation percentage (0%=not tilted,100%=maximum tilt) |
+
+## StatefulSiren
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `ring` |  | Ask the device to start ringing
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OnOffState` | `string` — `on`, `off` | Device on/off status |
+
+## StatefulSlidingPergola
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:DeploymentState` | `int` (0–100) | Device deployment percentage (0%=fully retracted, 100%=fully deployed) |
+
+## StatefulStartStop
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `start` |  | Start the default actuator behavior (movement, sound or timer)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:StartedStoppedState` | `string` — `started`, `stopped` | Indicate if the sequence if started or stopped |
+
+## StatefulStartStopOven
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `start` |  | Start the default actuator behavior (movement, sound or timer)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:StartedStoppedState` | `string` — `started`, `stopped` | Indicate if the sequence if started or stopped |
+
+## StatefulStartStopWashingMachine
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `start` |  | Start the default actuator behavior (movement, sound or timer)
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:StartedStoppedState` | `string` — `started`, `stopped` | Indicate if the sequence if started or stopped |
+
+## StatefulSwitchable
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `off` |  | Turn off the device
+ |
+| `on` |  | Turn on the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OnOffState` | `string` — `on`, `off` | Device on/off status |
+
+## StatefulSwitchableHeating
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `off` |  | Turn off the device
+ |
+| `on` |  | Turn on the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OnOffState` | `string` — `on`, `off` | Device on/off status |
+
+## StatefulSwitchableLight
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `off` |  | Turn off the device
+ |
+| `on` |  | Turn on the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OnOffState` | `string` — `on`, `off` | Device on/off status |
+
+## StatefulSwitchablePlug
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `off` |  | Turn off the device
+ |
+| `on` |  | Turn on the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OnOffState` | `string` — `on`, `off` | Device on/off status |
+
+## StatefulSwitchableVentilation
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `off` |  | Turn off the device
+ |
+| `on` |  | Turn on the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OnOffState` | `string` — `on`, `off` | Device on/off status |
+
+## StatefulThermostat
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setTargetTemperature` | `float` (12.0–30.0) | Set the new air temperature to reach
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:TargetTemperatureState` | `float` (12.0–30.0) | Room target temperature (°C) |
+
+## StatefulThermostatWithSensor
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setTargetTemperature` | `float` (12.0–30.0) | Set the new air temperature to reach
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:TargetTemperatureState` | `float` (12.0–30.0) | Room target temperature (°C) |
+| `core:TemperatureState` | `float` (-100.0–100.0) | Current room temperature (°C) |
+
+## StatefulVenetianBlind
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosureAndOrientation` | `int` (0–100), `int` (0–100) | Set both the closure level (0-100%) and relative slats orientation (0-100%) of the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ClosureState` | `int` (0–100) | Device closure percentage (0%=fully open, 100%=fully closed) |
+| `core:SlateOrientationState` | `int` (0–100) | Slats orientation percentage (0%=not tilted,100%=maximum tilt) |
+
+## StatefulVenetianSlats
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:SlateOrientationState` | `int` (0–100) | Slats orientation percentage (0%=not tilted,100%=maximum tilt) |
+
+## StatefulWindowLockWithOpeningStatus
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `lock` |  | Lock the device
+ |
+| `unlock` |  | Unlock the device
+ |
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:LockedUnlockedState` | `string` — `locked`, `unlocked` | Indicate if the device is locked or unlocked |
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+
+## StoppableMusicPlayer
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `pause` |  | Pause current action
+ |
+| `play` |  | Play media
+ |
+| `setVolume` | `int` (0–100) | Set the device output volume
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+
+## Switch
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ActionState` | `string` | Contains the id of current active button action (stateful information). Example, physical position of a switch. |
+| `core:AvailableActionsState` | `array` | List of action ids available |
+
+## SwitchEvent
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:AvailableActionsState` | `array` | List of action ids available |
+| `core:ButtonActionsEventState` | `string` | Contains the id of triggered button action (stateless information, makes sense only punctually at a certain time, does not indicate a stable or continuous status). |
+
+## Switchable
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `off` |  | Turn off the device
+ |
+| `on` |  | Turn on the device
+ |
+
+## SwitchableHeating
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `off` |  | Turn off the device
+ |
+| `on` |  | Turn on the device
+ |
+
+## SwitchableHeatingStatus
+
+*Form factor specific* — tied to a specific physical device type.
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OnOffState` | `string` — `on`, `off` | Device on/off status |
+
+## SwitchableLight
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `off` |  | Turn off the device
+ |
+| `on` |  | Turn on the device
+ |
+
+## SwitchablePlug
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `off` |  | Turn off the device
+ |
+| `on` |  | Turn on the device
+ |
+
+## SwitchableVentilation
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `off` |  | Turn off the device
+ |
+| `on` |  | Turn on the device
+ |
+
+## Temperature
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:TemperatureState` | `float` (-100.0–100.0) | Current room temperature (°C) |
+
+## ThermalEnergyConsumption
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ThermalEnergyConsumptionState` | `int` (≥ 0) | Thermal energy consumption index (Wh) |
+
+## Thermostat
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setTargetTemperature` | `float` (12.0–30.0) | Set the new air temperature to reach
+ |
+
+## ThermostatOffsetReader
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ThermostatOffsetState` | `int` (-5–5) | Thermostat offset (°C) |
+
+## ThermostatTargetReader
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:TargetTemperatureState` | `float` (12.0–30.0) | Room target temperature (°C) |
+
+## TiltableOpeningStatus
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+| `core:TiltedState` | `boolean` | Indicate if a device is titled or straight |
+
+## TiltableWindowOpeningStatus
+
+*Form factor specific* — tied to a specific physical device type.
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |
+| `core:TiltedState` | `boolean` | Indicate if a device is titled or straight |
+
+## TiltedStatus
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:TiltedState` | `boolean` | Indicate if a device is titled or straight |
+
+## UpDown
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `down` |  | Move the device completely down
+ |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
+ |
+| `up` |  | Move the device completely up
+ |
+
+## UpdatableComponent
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `update` |  | Update the gateway software. The update may have to be downloaded first, which can take a while.
+ |
+
+## VOCConcentration
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:VOCConcentrationState` | `float` (≥ 0.0) | Current volatile organic compounds concentration (ppm) |
+
+## VenetianBlind
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setClosureAndOrientation` | `int` (0–100), `int` (0–100) | Set both the closure level (0-100%) and relative slats orientation (0-100%) of the device
+ |
+
+## VenetianSlats
+
+*Form factor specific* — tied to a specific physical device type.
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
+ |
+
+## VibrationDetector
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:VibrationState` | `string` — `detected`, `notDetected` | Indicate if strong vibrations are detected or not |
+
+## VolumeControl
+
+### Commands
+
+| Command | Parameters | Description |
+|---------|-----------|-------------|
+| `setVolume` | `int` (0–100) | Set the device output volume
+ |
+
+## WaterConsumption
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:WaterConsumptionState` | `float` (≥ 0.0) | Water consumption index (m^3) |
+
+## WaterDetector
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:WaterDetectionState` | `string` — `detected`, `notDetected` | Indicate if a water leak is detected or not |
+
+## WindDirection
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:WindDirectionState` | `int` (0–360) | Wind direction (0°=North, clockwise) |
+
+## WindSpeed
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:WindSpeedState` | `float` (≥ 0.0) | Wind speed (km/h) |
+
+## WindSpeedAndDirection
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:WindDirectionState` | `int` (0–360) | Wind direction (0°=North, clockwise) |
+| `core:WindSpeedState` | `float` (≥ 0.0) | Wind speed (km/h) |
+
+## WindowContactAndVibrationSensor
+
+*Form factor specific* — tied to a specific physical device type.
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:ContactState` | `string` — `open`, `closed` | Contact sensor is open or closed |
+| `core:VibrationState` | `string` — `detected`, `notDetected` | Indicate if strong vibrations are detected or not |
+
+## WindowOpeningStatus
+
+*Form factor specific* — tied to a specific physical device type.
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `core:OpenClosedState` | `string` — `open`, `closed` | Indicate if the device is open or closed |

--- a/docs/ui-profiles.md
+++ b/docs/ui-profiles.md
@@ -18,8 +18,7 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setFanSpeedLevel` | `int` (0–100) | Set the device fan speed level (%)
- |
+| `setFanSpeedLevel` | `int` (0–100) | Set the device fan speed level (%) |
 
 ## AirFanMode
 
@@ -27,8 +26,7 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setFanSpeedMode` | `string` — `low`, `high` | Set the device fan speed mode
- |
+| `setFanSpeedMode` | `string` — `low`, `high` | Set the device fan speed mode |
 
 ## AirOutputLevelSensor
 
@@ -52,10 +50,8 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `arm` |  | Arm the system
- |
-| `disarm` |  | Disarm the system
- |
+| `arm` |  | Arm the system |
+| `disarm` |  | Disarm the system |
 
 ## AmbientNoiseSensor
 
@@ -71,8 +67,7 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
 
 ## BasicOpenClose
 
@@ -80,10 +75,8 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
 
 ## BasicUpDown
 
@@ -91,10 +84,8 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `down` |  | Move the device completely down
- |
-| `up` |  | Move the device completely up
- |
+| `down` |  | Move the device completely down |
+| `up` |  | Move the device completely up |
 
 ## BatteryStatus
 
@@ -142,10 +133,8 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## CloseableBlind
 
@@ -155,10 +144,8 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## CloseableCurtain
 
@@ -168,10 +155,8 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## CloseableScreen
 
@@ -181,10 +166,8 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## CloseableShutter
 
@@ -194,10 +177,8 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## CloseableWindow
 
@@ -207,10 +188,8 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## ContactAndVibrationDetector
 
@@ -235,8 +214,7 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point)
- |
+| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point) |
 
 ## Cyclic
 
@@ -244,8 +222,7 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `cycle` |  | Do a cycle of supported motion kinematics or modes
- |
+| `cycle` |  | Do a cycle of supported motion kinematics or modes |
 
 ## CyclicGarageOpener
 
@@ -255,8 +232,7 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `cycle` |  | Do a cycle of supported motion kinematics or modes
- |
+| `cycle` |  | Do a cycle of supported motion kinematics or modes |
 
 ## CyclicGateOpener
 
@@ -266,8 +242,7 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `cycle` |  | Do a cycle of supported motion kinematics or modes
- |
+| `cycle` |  | Do a cycle of supported motion kinematics or modes |
 
 ## DHWTemperature
 
@@ -283,8 +258,7 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setTargetDHWTemperature` | `float` (38.0–60.0) | Set the new water temperature to reach for a Domestic Hot Water system
- |
+| `setTargetDHWTemperature` | `float` (38.0–60.0) | Set the new water temperature to reach for a Domestic Hot Water system |
 
 ## DHWThermostatTargetReader
 
@@ -300,10 +274,8 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `deploy` |  | Fully deploy the device
- |
-| `undeploy` |  | Fully undeploy the device
- |
+| `deploy` |  | Fully deploy the device |
+| `undeploy` |  | Fully undeploy the device |
 
 ## DeployUndeployAwning
 
@@ -313,10 +285,8 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `deploy` |  | Fully deploy the device
- |
-| `undeploy` |  | Fully undeploy the device
- |
+| `deploy` |  | Fully deploy the device |
+| `undeploy` |  | Fully undeploy the device |
 
 ## Deployable
 
@@ -324,8 +294,7 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed)
- |
+| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed) |
 
 ## DeployableAwning
 
@@ -335,8 +304,7 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed)
- |
+| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed) |
 
 ## DeployableVerticalAwning
 
@@ -346,8 +314,7 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed)
- |
+| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed) |
 
 ## Dimmable
 
@@ -355,8 +322,7 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setIntensity` | `int` (0–100) | Light intensity level (100%=maximum intensity, 0%=off)
- |
+| `setIntensity` | `int` (0–100) | Light intensity level (100%=maximum intensity, 0%=off) |
 
 ## DoorContactSensor
 
@@ -384,10 +350,8 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point)
- |
-| `setHeatingTargetTemperature` | `float` (7.0–35.0) | Set the heating target temperature (manual set point)
- |
+| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point) |
+| `setHeatingTargetTemperature` | `float` (7.0–35.0) | Set the heating target temperature (manual set point) |
 
 ## ElectricCurrentMeter
 
@@ -456,8 +420,7 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setHeatingLevel` | `string` — `comfort`, `eco` | Sets the device heating level mode
- |
+| `setHeatingLevel` | `string` — `comfort`, `eco` | Sets the device heating level mode |
 
 ## IntrusionDetector
 
@@ -481,9 +444,7 @@ UI profiles describe device capabilities through the commands they accept and th
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setLevel` | `int` (0–100) | Generic device working level (0-100%)
-Functional meaning depends on device
- |
+| `setLevel` | `int` (0–100) | Generic device working level (0-100%) Functional meaning depends on device |
 
 ## LightDimmer
 
@@ -493,8 +454,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setIntensity` | `int` (0–100) | Light intensity level (100%=maximum intensity, 0%=off)
- |
+| `setIntensity` | `int` (0–100) | Light intensity level (100%=maximum intensity, 0%=off) |
 
 ## Lock
 
@@ -502,10 +462,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `lock` |  | Lock the device
- |
-| `unlock` |  | Unlock the device
- |
+| `lock` |  | Lock the device |
+| `unlock` |  | Unlock the device |
 
 ## LockStatus
 
@@ -560,12 +518,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `pause` |  | Pause current action
- |
-| `play` |  | Play media
- |
-| `setVolume` | `int` (0–100) | Set the device output volume
- |
+| `pause` |  | Pause current action |
+| `play` |  | Play media |
+| `setVolume` | `int` (0–100) | Set the device output volume |
 
 ## OccupancyDetector
 
@@ -597,12 +552,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## OpenCloseBlind
 
@@ -612,12 +564,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## OpenCloseCameraShutter
 
@@ -627,10 +576,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
 
 ## OpenCloseCurtain
 
@@ -640,12 +587,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## OpenCloseGarageOpener
 
@@ -655,12 +599,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## OpenCloseGateOpener
 
@@ -670,12 +611,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## OpenCloseScreen
 
@@ -685,12 +623,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## OpenCloseShutter
 
@@ -700,12 +635,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## OpenCloseShutterSwitch
 
@@ -715,10 +647,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
 
 ## OpenCloseSlidingGateOpener
 
@@ -728,12 +658,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## OpenCloseSwingingShutter
 
@@ -743,12 +670,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## OpenCloseWindow
 
@@ -758,12 +682,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## OpeningStatus
 
@@ -779,8 +700,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setOperatingMode` | `any` | Set an operating mode
- |
+| `setOperatingMode` | `any` | Set an operating mode |
 
 ## OrientableAndCloseable
 
@@ -788,8 +708,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosureAndOrientation` | `int` (0–100), `int` (0–100) | Set both the closure level (0-100%) and relative slats orientation (0-100%) of the device
- |
+| `setClosureAndOrientation` | `int` (0–100), `int` (0–100) | Set both the closure level (0-100%) and relative slats orientation (0-100%) of the device |
 
 ## OrientableOrCloseable
 
@@ -805,12 +724,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## OrientableSlats
 
@@ -818,8 +734,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
- |
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats |
 
 ## PictureCamera
 
@@ -827,8 +742,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `takePicture` |  | Take a still picture
- |
+| `takePicture` |  | Take a still picture |
 
 ## PowerCutDetector
 
@@ -876,10 +790,7 @@ Functional meaning depends on device
 
 | State | Type | Description |
 |-------|------|-------------|
-| `core:LaunchStatusState` | `string` — `launched`, `standby` | Indicates if the scene is launched or standby.
-"launched" value indicates that the launch conditions have been met (ex button pressed on a remote controller).
-"standby" value matches with an intermediate status, typically between two launch actions (ex button released on a remote controller).
-"launched" value should be used during a very short time and not persist across different launch events, whereas "standby" is a more stable value. |
+| `core:LaunchStatusState` | `string` — `launched`, `standby` | Indicates if the scene is launched or standby. "launched" value indicates that the launch conditions have been met (ex button pressed on a remote controller). "standby" value matches with an intermediate status, typically between two launch actions (ex button released on a remote controller). "launched" value should be used during a very short time and not persist across different launch events, whereas "standby" is a more stable value. |
 
 ## Siren
 
@@ -887,10 +798,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `ring` |  | Ask the device to start ringing
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `ring` |  | Ask the device to start ringing |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## SlidingPergola
 
@@ -900,8 +809,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed)
- |
+| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed) |
 
 ## SmokeDetector
 
@@ -921,10 +829,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `start` |  | Start the default actuator behavior (movement, sound or timer)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `start` |  | Start the default actuator behavior (movement, sound or timer) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## StatefulAirFan
 
@@ -932,8 +838,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setFanSpeedLevel` | `int` (0–100) | Set the device fan speed level (%)
- |
+| `setFanSpeedLevel` | `int` (0–100) | Set the device fan speed level (%) |
 
 ### States
 
@@ -947,10 +852,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `arm` |  | Arm the system
- |
-| `disarm` |  | Disarm the system
- |
+| `arm` |  | Arm the system |
+| `disarm` |  | Disarm the system |
 
 ### States
 
@@ -964,8 +867,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
 
 ### States
 
@@ -979,10 +881,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
 
 ### States
 
@@ -998,8 +898,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
- |
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats |
 
 ### States
 
@@ -1015,10 +914,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `lock` |  | Lock the device
- |
-| `unlock` |  | Unlock the device
- |
+| `lock` |  | Lock the device |
+| `unlock` |  | Unlock the device |
 
 ### States
 
@@ -1033,10 +930,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1052,8 +947,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
 
 ### States
 
@@ -1069,10 +963,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1088,10 +980,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1107,10 +997,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1126,10 +1014,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1145,10 +1031,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1164,10 +1048,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1183,10 +1065,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1202,10 +1082,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1221,10 +1099,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1240,8 +1116,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
 
 ### States
 
@@ -1257,10 +1132,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1274,8 +1147,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point)
- |
+| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point) |
 
 ### States
 
@@ -1289,8 +1161,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point)
- |
+| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point) |
 
 ### States
 
@@ -1305,8 +1176,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setTargetDHWTemperature` | `float` (38.0–60.0) | Set the new water temperature to reach for a Domestic Hot Water system
- |
+| `setTargetDHWTemperature` | `float` (38.0–60.0) | Set the new water temperature to reach for a Domestic Hot Water system |
 
 ### States
 
@@ -1320,10 +1190,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `deploy` |  | Fully deploy the device
- |
-| `undeploy` |  | Fully undeploy the device
- |
+| `deploy` |  | Fully deploy the device |
+| `undeploy` |  | Fully undeploy the device |
 
 ### States
 
@@ -1339,10 +1207,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `deploy` |  | Fully deploy the device
- |
-| `undeploy` |  | Fully undeploy the device
- |
+| `deploy` |  | Fully deploy the device |
+| `undeploy` |  | Fully undeploy the device |
 
 ### States
 
@@ -1356,8 +1222,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed)
- |
+| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed) |
 
 ### States
 
@@ -1373,8 +1238,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed)
- |
+| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed) |
 
 ### States
 
@@ -1390,8 +1254,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed)
- |
+| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed) |
 
 ### States
 
@@ -1405,8 +1268,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setIntensity` | `int` (0–100) | Light intensity level (100%=maximum intensity, 0%=off)
- |
+| `setIntensity` | `int` (0–100) | Light intensity level (100%=maximum intensity, 0%=off) |
 
 ### States
 
@@ -1422,10 +1284,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `lock` |  | Lock the device
- |
-| `unlock` |  | Unlock the device
- |
+| `lock` |  | Lock the device |
+| `unlock` |  | Unlock the device |
 
 ### States
 
@@ -1441,10 +1301,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `lock` |  | Lock the device
- |
-| `unlock` |  | Unlock the device
- |
+| `lock` |  | Lock the device |
+| `unlock` |  | Unlock the device |
 
 ### States
 
@@ -1459,10 +1317,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point)
- |
-| `setHeatingTargetTemperature` | `float` (7.0–35.0) | Set the heating target temperature (manual set point)
- |
+| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point) |
+| `setHeatingTargetTemperature` | `float` (7.0–35.0) | Set the heating target temperature (manual set point) |
 
 ### States
 
@@ -1477,10 +1333,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point)
- |
-| `setHeatingTargetTemperature` | `float` (7.0–35.0) | Set the heating target temperature (manual set point)
- |
+| `setCoolingTargetTemperature` | `float` (7.0–35.0) | Set the cooling target temperature (manual set point) |
+| `setHeatingTargetTemperature` | `float` (7.0–35.0) | Set the heating target temperature (manual set point) |
 
 ### States
 
@@ -1496,8 +1350,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setHeatingLevel` | `string` — `comfort`, `eco` | Sets the device heating level mode
- |
+| `setHeatingLevel` | `string` — `comfort`, `eco` | Sets the device heating level mode |
 
 ### States
 
@@ -1511,9 +1364,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setLevel` | `int` (0–100) | Generic device working level (0-100%)
-Functional meaning depends on device
- |
+| `setLevel` | `int` (0–100) | Generic device working level (0-100%) Functional meaning depends on device |
 
 ### States
 
@@ -1529,9 +1380,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setLevel` | `int` (0–100) | Generic device working level (0-100%)
-Functional meaning depends on device
- |
+| `setLevel` | `int` (0–100) | Generic device working level (0-100%) Functional meaning depends on device |
 
 ### States
 
@@ -1547,8 +1396,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setIntensity` | `int` (0–100) | Light intensity level (100%=maximum intensity, 0%=off)
- |
+| `setIntensity` | `int` (0–100) | Light intensity level (100%=maximum intensity, 0%=off) |
 
 ### States
 
@@ -1562,10 +1410,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `lock` |  | Lock the device
- |
-| `unlock` |  | Unlock the device
- |
+| `lock` |  | Lock the device |
+| `unlock` |  | Unlock the device |
 
 ### States
 
@@ -1579,10 +1425,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `lock` |  | Lock the device
- |
-| `unlock` |  | Unlock the device
- |
+| `lock` |  | Lock the device |
+| `unlock` |  | Unlock the device |
 
 ### States
 
@@ -1597,12 +1441,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1618,12 +1459,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1639,12 +1477,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1660,12 +1495,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1681,10 +1513,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `close` |  | Fully close the device
- |
-| `open` |  | Fully open the device
- |
+| `close` |  | Fully close the device |
+| `open` |  | Fully open the device |
 
 ### States
 
@@ -1698,8 +1528,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setOperatingMode` | `any` | Set an operating mode
- |
+| `setOperatingMode` | `any` | Set an operating mode |
 
 ### States
 
@@ -1713,8 +1542,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosureAndOrientation` | `int` (0–100), `int` (0–100) | Set both the closure level (0-100%) and relative slats orientation (0-100%) of the device
- |
+| `setClosureAndOrientation` | `int` (0–100), `int` (0–100) | Set both the closure level (0-100%) and relative slats orientation (0-100%) of the device |
 
 ### States
 
@@ -1731,8 +1559,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosureAndOrientation` | `int` (0–100), `int` (0–100) | Set both the closure level (0-100%) and relative slats orientation (0-100%) of the device
- |
+| `setClosureAndOrientation` | `int` (0–100), `int` (0–100) | Set both the closure level (0-100%) and relative slats orientation (0-100%) of the device |
 
 ### States
 
@@ -1762,12 +1589,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1784,12 +1608,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1806,12 +1627,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open)
- |
-| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `setClosure` | `int` (0–100) | Closure level (100%=fully close, 0%=open) |
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1826,8 +1644,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
- |
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats |
 
 ### States
 
@@ -1858,10 +1675,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `ring` |  | Ask the device to start ringing
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `ring` |  | Ask the device to start ringing |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1877,8 +1692,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed)
- |
+| `setDeployment` | `int` (0–100) | Device deployment level (100%=fully deployed, 0%=fully undeployed) |
 
 ### States
 
@@ -1892,10 +1706,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `start` |  | Start the default actuator behavior (movement, sound or timer)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `start` |  | Start the default actuator behavior (movement, sound or timer) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1911,10 +1723,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `start` |  | Start the default actuator behavior (movement, sound or timer)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `start` |  | Start the default actuator behavior (movement, sound or timer) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1930,10 +1740,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `start` |  | Start the default actuator behavior (movement, sound or timer)
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `start` |  | Start the default actuator behavior (movement, sound or timer) |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ### States
 
@@ -1947,10 +1755,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `off` |  | Turn off the device
- |
-| `on` |  | Turn on the device
- |
+| `off` |  | Turn off the device |
+| `on` |  | Turn on the device |
 
 ### States
 
@@ -1966,10 +1772,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `off` |  | Turn off the device
- |
-| `on` |  | Turn on the device
- |
+| `off` |  | Turn off the device |
+| `on` |  | Turn on the device |
 
 ### States
 
@@ -1985,10 +1789,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `off` |  | Turn off the device
- |
-| `on` |  | Turn on the device
- |
+| `off` |  | Turn off the device |
+| `on` |  | Turn on the device |
 
 ### States
 
@@ -2004,10 +1806,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `off` |  | Turn off the device
- |
-| `on` |  | Turn on the device
- |
+| `off` |  | Turn off the device |
+| `on` |  | Turn on the device |
 
 ### States
 
@@ -2023,10 +1823,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `off` |  | Turn off the device
- |
-| `on` |  | Turn on the device
- |
+| `off` |  | Turn off the device |
+| `on` |  | Turn on the device |
 
 ### States
 
@@ -2040,8 +1838,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setTargetTemperature` | `float` (12.0–30.0) | Set the new air temperature to reach
- |
+| `setTargetTemperature` | `float` (12.0–30.0) | Set the new air temperature to reach |
 
 ### States
 
@@ -2055,8 +1852,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setTargetTemperature` | `float` (12.0–30.0) | Set the new air temperature to reach
- |
+| `setTargetTemperature` | `float` (12.0–30.0) | Set the new air temperature to reach |
 
 ### States
 
@@ -2073,8 +1869,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosureAndOrientation` | `int` (0–100), `int` (0–100) | Set both the closure level (0-100%) and relative slats orientation (0-100%) of the device
- |
+| `setClosureAndOrientation` | `int` (0–100), `int` (0–100) | Set both the closure level (0-100%) and relative slats orientation (0-100%) of the device |
 
 ### States
 
@@ -2091,8 +1886,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
- |
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats |
 
 ### States
 
@@ -2108,10 +1902,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `lock` |  | Lock the device
- |
-| `unlock` |  | Unlock the device
- |
+| `lock` |  | Lock the device |
+| `unlock` |  | Unlock the device |
 
 ### States
 
@@ -2126,14 +1918,10 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `pause` |  | Pause current action
- |
-| `play` |  | Play media
- |
-| `setVolume` | `int` (0–100) | Set the device output volume
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
+| `pause` |  | Pause current action |
+| `play` |  | Play media |
+| `setVolume` | `int` (0–100) | Set the device output volume |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
 
 ## Switch
 
@@ -2159,10 +1947,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `off` |  | Turn off the device
- |
-| `on` |  | Turn on the device
- |
+| `off` |  | Turn off the device |
+| `on` |  | Turn on the device |
 
 ## SwitchableHeating
 
@@ -2172,10 +1958,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `off` |  | Turn off the device
- |
-| `on` |  | Turn on the device
- |
+| `off` |  | Turn off the device |
+| `on` |  | Turn on the device |
 
 ## SwitchableHeatingStatus
 
@@ -2195,10 +1979,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `off` |  | Turn off the device
- |
-| `on` |  | Turn on the device
- |
+| `off` |  | Turn off the device |
+| `on` |  | Turn on the device |
 
 ## SwitchablePlug
 
@@ -2208,10 +1990,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `off` |  | Turn off the device
- |
-| `on` |  | Turn on the device
- |
+| `off` |  | Turn off the device |
+| `on` |  | Turn on the device |
 
 ## SwitchableVentilation
 
@@ -2221,10 +2001,8 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `off` |  | Turn off the device
- |
-| `on` |  | Turn on the device
- |
+| `off` |  | Turn off the device |
+| `on` |  | Turn on the device |
 
 ## Temperature
 
@@ -2248,8 +2026,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setTargetTemperature` | `float` (12.0–30.0) | Set the new air temperature to reach
- |
+| `setTargetTemperature` | `float` (12.0–30.0) | Set the new air temperature to reach |
 
 ## ThermostatOffsetReader
 
@@ -2301,12 +2078,9 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `down` |  | Move the device completely down
- |
-| `stop` |  | Stop the current actuator behavior (movement, sound or timer)
- |
-| `up` |  | Move the device completely up
- |
+| `down` |  | Move the device completely down |
+| `stop` |  | Stop the current actuator behavior (movement, sound or timer) |
+| `up` |  | Move the device completely up |
 
 ## UpdatableComponent
 
@@ -2314,8 +2088,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `update` |  | Update the gateway software. The update may have to be downloaded first, which can take a while.
- |
+| `update` |  | Update the gateway software. The update may have to be downloaded first, which can take a while. |
 
 ## VOCConcentration
 
@@ -2333,8 +2106,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setClosureAndOrientation` | `int` (0–100), `int` (0–100) | Set both the closure level (0-100%) and relative slats orientation (0-100%) of the device
- |
+| `setClosureAndOrientation` | `int` (0–100), `int` (0–100) | Set both the closure level (0-100%) and relative slats orientation (0-100%) of the device |
 
 ## VenetianSlats
 
@@ -2344,8 +2116,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats
- |
+| `setOrientation` | `int` (0–100) | Set the relative orientation (0-100%) of the device slats |
 
 ## VibrationDetector
 
@@ -2361,8 +2132,7 @@ Functional meaning depends on device
 
 | Command | Parameters | Description |
 |---------|-----------|-------------|
-| `setVolume` | `int` (0–100) | Set the device output volume
- |
+| `setVolume` | `int` (0–100) | Set the device output volume |
 
 ## WaterConsumption
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,5 +51,7 @@ nav:
       - Event handling: event-handling.md
       - Troubleshooting: troubleshooting.md
       - Migrating from v1: migration-v2.md
-  - API Reference: api-reference.md
+  - Reference:
+      - API Reference: api-reference.md
+      - UI Profiles: ui-profiles.md
   - Contribute: contribute.md

--- a/utils/generate_enums.py
+++ b/utils/generate_enums.py
@@ -438,6 +438,95 @@ async def generate_ui_profiles(server: Server) -> None:
             f"✓ Profiles without details: {sum(1 for _, d in profiles_with_details if d is None)}"
         )
 
+        generate_ui_profiles_docs(profiles_with_details)
+
+
+def generate_ui_profiles_docs(
+    profiles_with_details: list[tuple[str, UIProfileDefinition | None]],
+) -> None:
+    """Generate a documentation page for UI profiles."""
+
+    def format_type(vp: ValuePrototype) -> str:
+        """Format a value prototype into a readable type string."""
+        type_str = f"`{vp.type.lower()}`"
+        if vp.min_value is not None and vp.max_value is not None:
+            type_str += f" ({vp.min_value}\N{EN DASH}{vp.max_value})"
+        elif vp.min_value is not None:
+            type_str += f" (≥ {vp.min_value})"
+        elif vp.max_value is not None:
+            type_str += f" (≤ {vp.max_value})"
+        if vp.enum_values:
+            type_str += " — " + ", ".join(f"`{v}`" for v in vp.enum_values)
+        return type_str
+
+    lines = [
+        "---",
+        "hide:",
+        "  - toc",
+        "---",
+        "",
+        "# UI Profiles",
+        "",
+        "UI profiles describe device capabilities through the commands they accept and the states they expose. Each device has one or more profiles that define what it can do.",
+        "",
+        "!!! note",
+        "    This page is auto-generated from the Overkiz API. Run `uv run utils/generate_enums.py` to regenerate.",
+        "",
+        f"**{len(profiles_with_details)} profiles** documented below.",
+        "",
+    ]
+
+    for profile_name, details in profiles_with_details:
+        lines.append(f"## {profile_name}")
+        lines.append("")
+
+        if details is None:
+            lines.append("*Details unavailable.*")
+            lines.append("")
+            continue
+
+        if details.form_factor:
+            lines.append(
+                "*Form factor specific* — tied to a specific physical device type."
+            )
+            lines.append("")
+
+        if details.commands:
+            lines.append("### Commands")
+            lines.append("")
+            lines.append("| Command | Parameters | Description |")
+            lines.append("|---------|-----------|-------------|")
+            for cmd in details.commands:
+                params = ""
+                if cmd.prototype and cmd.prototype.parameters:
+                    param_parts = []
+                    for param in cmd.prototype.parameters:
+                        if param.value_prototypes:
+                            param_parts.append(format_type(param.value_prototypes[0]))
+                        else:
+                            param_parts.append("—")
+                    params = ", ".join(param_parts)
+                desc = cmd.description or ""
+                lines.append(f"| `{cmd.name}` | {params} | {desc} |")
+            lines.append("")
+
+        if details.states:
+            lines.append("### States")
+            lines.append("")
+            lines.append("| State | Type | Description |")
+            lines.append("|-------|------|-------------|")
+            for state in details.states:
+                type_info = ""
+                if state.prototype and state.prototype.value_prototypes:
+                    type_info = format_type(state.prototype.value_prototypes[0])
+                desc = state.description or ""
+                lines.append(f"| `{state.name}` | {type_info} | {desc} |")
+            lines.append("")
+
+    output_path = Path(__file__).parent.parent / "docs" / "ui-profiles.md"
+    output_path.write_text("\n".join(lines))
+    print(f"✓ Generated {output_path}")
+
 
 def extract_commands_from_fixtures(fixtures_dir: Path) -> set[str]:
     """Extract all commands from fixture files in the given directory.

--- a/utils/generate_enums.py
+++ b/utils/generate_enums.py
@@ -506,7 +506,7 @@ def generate_ui_profiles_docs(
                         else:
                             param_parts.append("—")
                     params = ", ".join(param_parts)
-                desc = cmd.description or ""
+                desc = (cmd.description or "").replace("\n", " ").replace("|", "\\|")
                 lines.append(f"| `{cmd.name}` | {params} | {desc} |")
             lines.append("")
 
@@ -519,12 +519,12 @@ def generate_ui_profiles_docs(
                 type_info = ""
                 if state.prototype and state.prototype.value_prototypes:
                     type_info = format_type(state.prototype.value_prototypes[0])
-                desc = state.description or ""
+                desc = (state.description or "").replace("\n", " ").replace("|", "\\|")
                 lines.append(f"| `{state.name}` | {type_info} | {desc} |")
             lines.append("")
 
     output_path = Path(__file__).parent.parent / "docs" / "ui-profiles.md"
-    output_path.write_text("\n".join(lines))
+    output_path.write_text("\n".join(lines), encoding="utf-8", newline="\n")
     print(f"✓ Generated {output_path}")
 
 


### PR DESCRIPTION
## Summary
- Extends `utils/generate_enums.py` to also output `docs/ui-profiles.md` alongside the enum file, using the same API data it already fetches
- Each profile gets its own section with commands table (name, parameters, description) and states table (name, type, description)
- Restructures mkdocs nav to add a "Reference" section containing API Reference and UI Profiles
- Initial page generated from existing enum comments (187 profiles)

## Test plan
- [x] `mkdocs build --strict` passes
- [x] `ruff check` passes
- [x] `mypy` passes
- [x] Verified rendered output for profiles with commands, states, form factor, and both