### PR TITLE
Fix docs workflow not triggering on release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,8 @@ name: docs
 on:
   release:
     types:
-      - created
+      - published
+  workflow_dispatch:
   pull_request:
     paths:
       - docs/**


### PR DESCRIPTION
## Summary
- Change release event type from `created` to `published` to match the actual event fired by GitHub when releases are created via the UI
- Add `workflow_dispatch` to allow manual documentation publishing from the Actions tab

## Context
The docs workflow never triggered on releases because GitHub fires `published` (not `created`) when a release is created directly via the UI. The `release.yml` (PyPI publish) already uses `published` correctly.

## Test plan
- [ ] Merge PR and trigger manually via `gh workflow run docs.yml --ref main`
- [ ] Verify docs deploy on next release