### PR TITLE
Deploy docs on manual workflow_dispatch trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
           path: site
 
   deploy:
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Allow the deploy job to run when the docs workflow is triggered manually via `workflow_dispatch`
- Previously, manual triggers would build the docs but skip deployment since the condition only checked for `release` events

## Context
Follow-up to #2055. The `workflow_dispatch` trigger was added but the deploy job's `if` condition still only allowed `release` events through.

## Test plan
- [ ] Merge and run `gh workflow run docs.yml --ref main`
- [ ] Verify docs are deployed to GitHub Pages