### PR TITLE
Add documentation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A fully asynchronous and user-friendly API client for the OverKiz platform. This client enables interaction with smart devices connected to OverKiz, supporting multiple vendors such as Somfy TaHoma and Atlantic Cozytouch.
 
+For full documentation, visit [imicknl.github.io/python-overkiz-api](https://imicknl.github.io/python-overkiz-api/).
+
 This package is primarily used by Home Assistant Core to provide the Overkiz integration. If you wish to use this package in your own project, refer to the [examples below](#getting-started) or explore the [Home Assistant source code](https://github.com/home-assistant/core/tree/dev/homeassistant/components/overkiz) for additional usage examples.
 
 ## Supported hubs

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 A fully asynchronous and user-friendly API client for the OverKiz platform. This client enables interaction with smart devices connected to OverKiz, supporting multiple vendors such as Somfy TaHoma and Atlantic Cozytouch.
 
-For full documentation, visit [imicknl.github.io/python-overkiz-api](https://imicknl.github.io/python-overkiz-api/).
-
-This package is primarily used by Home Assistant Core to provide the Overkiz integration. If you wish to use this package in your own project, refer to the [examples below](#getting-started) or explore the [Home Assistant source code](https://github.com/home-assistant/core/tree/dev/homeassistant/components/overkiz) for additional usage examples.
+This package is primarily used by Home Assistant Core to provide the Overkiz integration. If you wish to use this package in your own project, refer to the [full documentation](https://imicknl.github.io/python-overkiz-api/), the [examples below](#getting-started), or explore the [Home Assistant source code](https://github.com/home-assistant/core/tree/dev/homeassistant/components/overkiz) for additional usage examples.
 
 ## Supported hubs
 


### PR DESCRIPTION
## Summary
- Add a link to the full documentation site (imicknl.github.io/python-overkiz-api) in the README introduction

## Test plan
- [x] Verify link renders correctly in markdown