### PR TITLE
Make Device.definition non-optional

### DIFF
--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -442,7 +442,7 @@ class Device:
     label: str = field(repr=obfuscate_string)
     device_url: str = field(repr=obfuscate_id)
     controllable_name: str
-    definition: Definition | None = None
+    definition: Definition
     states: States = field(factory=States)
     type: ProductType
     ui_class: UIClass = field(default=None)  # type: ignore[assignment]
@@ -461,12 +461,11 @@ class Device:
         """Resolve computed fields from device URL and definition fallbacks."""
         self.identifier = DeviceIdentifier.from_device_url(self.device_url)
 
-        if self.definition:
-            if self.ui_class is None and self.definition.ui_class:
-                self.ui_class = UIClass(self.definition.ui_class)
+        if self.ui_class is None and self.definition.ui_class:
+            self.ui_class = UIClass(self.definition.ui_class)
 
-            if self.widget is None and self.definition.widget_name:
-                self.widget = UIWidget(self.definition.widget_name)
+        if self.widget is None and self.definition.widget_name:
+            self.widget = UIWidget(self.definition.widget_name)
 
         if self.ui_class is None or self.widget is None:
             raise OverkizError(
@@ -475,26 +474,20 @@ class Device:
 
     def supports_command(self, command: str | OverkizCommand) -> bool:
         """Check if device supports a command."""
-        return self.definition is not None and str(command) in self.definition.commands
+        return str(command) in self.definition.commands
 
     def supports_any_command(self, commands: list[str | OverkizCommand]) -> bool:
         """Check if device supports any of the commands."""
-        return self.definition is not None and self.definition.commands.has_any(
-            commands
-        )
+        return self.definition.commands.has_any(commands)
 
     def first_command(self, commands: list[str | OverkizCommand]) -> str | None:
         """Return first supported command name from list, or None."""
-        if self.definition is None:
-            return None
         return self.definition.commands.first(commands)
 
     def get_command_definition(
         self, command: str | OverkizCommand
     ) -> CommandDefinition | None:
         """Return the CommandDefinition for a command, or None if unavailable."""
-        if self.definition is None:
-            return None
         return self.definition.commands.get(str(command))
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1128,8 +1128,8 @@ def test_get_command_definition_not_found():
     assert device.get_command_definition("open") is None
 
 
-def test_get_command_definition_no_definition():
-    """Device.get_command_definition() returns None when device has no definition."""
+def test_get_command_definition_empty_definition():
+    """Device.get_command_definition() returns None when command is not in definition."""
     from pyoverkiz.enums import ProductType
     from pyoverkiz.models import States
 
@@ -1140,9 +1140,7 @@ def test_get_command_definition_no_definition():
         label="Test",
         device_url="io://1234-5678-9012/1",
         controllable_name="test",
-        definition=None,
+        definition=Definition(widget_name="SomeWidget", ui_class="RollerShutter"),
         type=ProductType.ACTUATOR,
-        widget="SomeWidget",
-        ui_class="RollerShutter",
     )
     assert device.get_command_definition("open") is None

--- a/uv.lock
+++ b/uv.lock
@@ -1004,7 +1004,7 @@ wheels = [
 
 [[package]]
 name = "pyoverkiz"
-version = "2.0.0.dev0"
+version = "2.0.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Make `Device.definition` a required `Definition` field instead of `Definition | None`
- Remove unnecessary `None` guards in `supports_command`, `supports_any_command`, `first_command`, and `get_command_definition`
- The Overkiz API (both cloud and local) always returns a definition for every device — confirmed by all fixtures

## Test plan
- [x] All 438 tests pass
- [x] mypy passes with no issues
- [x] No fixture (cloud or local) has a device without a `definition` field