### PR TITLE
Auto-convert dicts to EventState in Event

### DIFF
--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -571,6 +571,14 @@ class Event:
     exec_id: str | None = None
     device_url: str | None = field(repr=obfuscate_id, default=None)
     device_states: list[EventState] = field(factory=list)
+
+    def __attrs_post_init__(self) -> None:
+        """Auto-convert dicts in device_states to EventState objects."""
+        states: list[Any] = self.device_states  # type: ignore[assignment]
+        self.device_states = [
+            EventState(**s) if isinstance(s, dict) else s for s in states
+        ]
+
     old_state: ExecutionState | None = None
     new_state: ExecutionState | None = None
     actions: list[Action] | None = None

--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -570,15 +570,12 @@ class Event:
     gateway_id: str | None = field(repr=obfuscate_id, default=None)
     exec_id: str | None = None
     device_url: str | None = field(repr=obfuscate_id, default=None)
-    device_states: list[EventState] = field(factory=list)
-
-    def __attrs_post_init__(self) -> None:
-        """Auto-convert dicts in device_states to EventState objects."""
-        states: list[Any] = self.device_states  # type: ignore[assignment]
-        self.device_states = [
+    device_states: list[EventState] = field(
+        factory=list,
+        converter=lambda states: [
             EventState(**s) if isinstance(s, dict) else s for s in states
-        ]
-
+        ],
+    )
     old_state: ExecutionState | None = None
     new_state: ExecutionState | None = None
     actions: list[Action] | None = None


### PR DESCRIPTION
## Summary
- Adds `__attrs_post_init__` to `Event` that auto-converts dicts in `device_states` to `EventState` objects
- Consumers constructing `Event` directly (e.g. in tests) no longer need to manually wrap dicts as `EventState(**state)`
- Existing cattrs structuring path is unaffected

## Test plan
- [x] All 438 existing tests pass
- [x] Verified direct construction with dicts works: `Event(name=..., device_states=[{"name": "...", "type": 3, "value": "open"}])`
- [x] Verified passing `EventState` objects directly still works
- [x] Pre-commit hooks pass (ruff, mypy, ty)