### PR TITLE
Fix RTS duration injection and add comprehensive tests

### DIFF
--- a/docs/device-control.md
+++ b/docs/device-control.md
@@ -309,7 +309,17 @@ client = OverkizClient(
 )
 ```
 
-With `rts_command_duration=0`, the execution duration is set to 0 seconds for supported commands, allowing consecutive commands to be sent without delay. Commands that don't accept a duration parameter (like `identify` or `test`) are left unchanged.
+With `rts_command_duration=0`, the execution duration is set to 0 seconds for supported commands, allowing consecutive commands to be sent without delay.
+
+For RTS commands, the **last parameter is always the execution duration**. The client injects the configured duration only when all other parameters have been provided (i.e., `current_count == nparams - 1`). This means:
+
+| Command | nparams | Behavior |
+|---------|---------|----------|
+| `close`, `open`, `up`, `down`, `stop`, `my`, `rest` | 1 | Duration injected when called with no args |
+| `tiltPositive`, `tiltNegative`, `moveOf` | 2 | Duration injected when called with position arg only |
+| `identify`, `test` | 0 | Never injected (no parameters accepted) |
+
+Commands that already have all parameters filled, or where required domain parameters (like position) have not been provided yet, are left unchanged.
 
 ## Limitations and rate limits
 

--- a/docs/device-control.md
+++ b/docs/device-control.md
@@ -294,7 +294,9 @@ trigger_id = await client.schedule_persisted_action_group(
 
 ## RTS command duration
 
-RTS devices have a default execution duration of 30 seconds, which blocks consecutive commands until the duration expires. To avoid this, you can configure `rts_command_duration` in `OverkizClientSettings`. The client will automatically inject the configured duration into RTS commands that support it, based on the command definition (`nparams`).
+For RTS commands, the **last parameter is always the execution duration** (defaults to 15–30 seconds depending on the command). This blocks consecutive commands until the duration expires.
+
+You can configure `default_rts_command_duration` in `OverkizClientSettings` to override this default. The client injects this value as the duration parameter only when the user has not already provided it explicitly.
 
 ```python
 from pyoverkiz.auth.credentials import UsernamePasswordCredentials
@@ -305,21 +307,19 @@ from pyoverkiz.enums import Server
 client = OverkizClient(
     server=Server.SOMFY_EUROPE,
     credentials=UsernamePasswordCredentials("user@example.com", "password"),
-    settings=OverkizClientSettings(rts_command_duration=0),
+    settings=OverkizClientSettings(default_rts_command_duration=0),
 )
 ```
 
-With `rts_command_duration=0`, the execution duration is set to 0 seconds for supported commands, allowing consecutive commands to be sent without delay.
+With `default_rts_command_duration=0`, consecutive commands can be sent without delay. If a user passes the duration explicitly (e.g., `Command(name="close", parameters=[5])`), their value takes precedence.
 
-For RTS commands, the **last parameter is always the execution duration**. The client injects the configured duration only when all other parameters have been provided (i.e., `current_count == nparams - 1`). This means:
+| Command | nparams | Last param | Injection behavior |
+|---------|---------|------------|--------------------|
+| `close`, `open`, `up`, `down`, `stop`, `my`, `rest` | 1 | duration (default 30s) | Injected when called with no args |
+| `tiltPositive`, `tiltNegative`, `moveOf` | 2 | duration (default 15s) | Injected when called with position arg only |
+| `identify`, `test` | 0 | — | Never injected (no parameters) |
 
-| Command | nparams | Behavior |
-|---------|---------|----------|
-| `close`, `open`, `up`, `down`, `stop`, `my`, `rest` | 1 | Duration injected when called with no args |
-| `tiltPositive`, `tiltNegative`, `moveOf` | 2 | Duration injected when called with position arg only |
-| `identify`, `test` | 0 | Never injected (no parameters accepted) |
-
-Commands that already have all parameters filled, or where required domain parameters (like position) have not been provided yet, are left unchanged.
+The injection rule: duration is injected only when all domain-specific parameters have been provided but the duration slot is still empty (`current_count == nparams - 1`). If the user already provides the duration themselves, the configured default is not applied.
 
 ## Limitations and rate limits
 

--- a/docs/migration-v2.md
+++ b/docs/migration-v2.md
@@ -406,7 +406,7 @@ These are not breaking, but worth knowing about when migrating:
 
 - **Client settings** — behavioral configuration is now grouped in `OverkizClientSettings`, passed via the `settings` parameter. This replaces standalone constructor parameters like `action_queue`.
 - **Action queue** — batch device executions automatically. See the [action queue guide](action-queue.md).
-- **RTS command duration** — automatically inject execution duration into RTS commands to prevent the default 30-second blocking behavior. See [RTS command duration](device-control.md#rts-command-duration).
+- **RTS command duration** — override the default execution duration for RTS commands (15–30s) to prevent blocking consecutive commands. See [RTS command duration](device-control.md#rts-command-duration).
 - **Device helpers** — `Device.get_command_definition()` for looking up command metadata.
 - **Reference endpoints** — query server metadata: `get_reference_ui_classes()`, `get_reference_ui_widgets()`, `get_reference_ui_profile()`, `get_reference_controllable_types()`, etc.
 - **Firmware management** — `get_devices_not_up_to_date()`, `get_device_firmware_status()`, `update_device_firmware()`.

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -519,6 +519,10 @@ class OverkizClient:
         blocks consecutive commands. This injects the configured duration
         (typically 0) into commands that accept it, based on the device
         command definition (nparams).
+
+        Only commands with nparams=1 that have no parameters yet are eligible.
+        Commands with nparams >= 2 (e.g. tiltPositive, moveOf) have
+        domain-specific parameters that are not execution duration.
         """
         duration = self.settings.rts_command_duration
         if duration is None:
@@ -539,11 +543,11 @@ class OverkizClient:
                 cmd_def = device.get_command_definition(str(cmd.name))
                 current_count = len(cmd.parameters) if cmd.parameters else 0
 
-                if cmd_def and current_count < cmd_def.nparams:
+                if cmd_def and cmd_def.nparams == 1 and current_count == 0:
                     updated_commands.append(
                         Command(
                             name=cmd.name,
-                            parameters=[*(cmd.parameters or []), duration],
+                            parameters=[duration],
                             type=cmd.type,
                         )
                     )

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -171,7 +171,7 @@ class OverkizClientSettings:
     """
 
     action_queue: ActionQueueSettings | None = None
-    rts_command_duration: int | None = None
+    default_rts_command_duration: int | None = None
 
 
 class OverkizClient:
@@ -513,19 +513,19 @@ class OverkizClient:
         return cast(str, response["protocolVersion"])
 
     def _apply_rts_duration(self, actions: list[Action]) -> list[Action]:
-        """Set the execution duration for RTS commands that support it.
+        """Apply the default execution duration for RTS commands.
 
-        The default execution duration for RTS devices is 30 seconds, which
-        blocks consecutive commands. This injects the configured duration
-        (typically 0) into commands that accept it, based on the device
-        command definition (nparams).
+        For RTS commands, the last parameter is always the execution duration
+        (default 15s for tilt commands, 30s for movement commands). This
+        injects ``default_rts_command_duration`` as the last parameter only
+        when the user has not already provided it — i.e., when the command
+        has all domain-specific parameters filled but the duration slot is
+        still empty (current_count == nparams - 1).
 
-        For RTS commands, the last parameter is always the execution duration.
-        Injection occurs only when the command is missing exactly that last
-        parameter (current_count == nparams - 1), ensuring we never fill
-        domain-specific parameter slots with a duration value.
+        If the user explicitly passes the duration parameter themselves, it
+        is left unchanged.
         """
-        duration = self.settings.rts_command_duration
+        duration = self.settings.default_rts_command_duration
         if duration is None:
             return actions
 

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -520,9 +520,10 @@ class OverkizClient:
         (typically 0) into commands that accept it, based on the device
         command definition (nparams).
 
-        Only commands with nparams=1 that have no parameters yet are eligible.
-        Commands with nparams >= 2 (e.g. tiltPositive, moveOf) have
-        domain-specific parameters that are not execution duration.
+        For RTS commands, the last parameter is always the execution duration.
+        Injection occurs only when the command is missing exactly that last
+        parameter (current_count == nparams - 1), ensuring we never fill
+        domain-specific parameter slots with a duration value.
         """
         duration = self.settings.rts_command_duration
         if duration is None:
@@ -543,11 +544,15 @@ class OverkizClient:
                 cmd_def = device.get_command_definition(str(cmd.name))
                 current_count = len(cmd.parameters) if cmd.parameters else 0
 
-                if cmd_def and cmd_def.nparams == 1 and current_count == 0:
+                if (
+                    cmd_def
+                    and cmd_def.nparams > 0
+                    and current_count == cmd_def.nparams - 1
+                ):
                     updated_commands.append(
                         Command(
                             name=cmd.name,
-                            parameters=[duration],
+                            parameters=[*(cmd.parameters or []), duration],
                             type=cmd.type,
                         )
                     )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1235,7 +1235,7 @@ class TestOverkizClientSettings:
     def test_client_with_settings_none(self, client: OverkizClient) -> None:
         """Client without settings has no action queue and no RTS duration."""
         assert client._action_queue is None
-        assert client.settings.rts_command_duration is None
+        assert client.settings.default_rts_command_duration is None
 
     @pytest.mark.asyncio
     async def test_client_with_rts_duration(self) -> None:
@@ -1243,9 +1243,9 @@ class TestOverkizClientSettings:
         client = OverkizClient(
             server=Server.SOMFY_EUROPE,
             credentials=UsernamePasswordCredentials("user", "pass"),
-            settings=OverkizClientSettings(rts_command_duration=0),
+            settings=OverkizClientSettings(default_rts_command_duration=0),
         )
-        assert client.settings.rts_command_duration == 0
+        assert client.settings.default_rts_command_duration == 0
 
     @pytest.mark.asyncio
     async def test_client_with_action_queue_via_settings(self) -> None:

--- a/tests/test_client_settings.py
+++ b/tests/test_client_settings.py
@@ -8,13 +8,13 @@ def test_defaults():
     """Default settings have no queue and no RTS duration."""
     settings = OverkizClientSettings()
     assert settings.action_queue is None
-    assert settings.rts_command_duration is None
+    assert settings.default_rts_command_duration is None
 
 
 def test_with_rts_duration():
     """RTS command duration can be set."""
-    settings = OverkizClientSettings(rts_command_duration=0)
-    assert settings.rts_command_duration == 0
+    settings = OverkizClientSettings(default_rts_command_duration=0)
+    assert settings.default_rts_command_duration == 0
 
 
 def test_with_action_queue_settings():

--- a/tests/test_rts_injection.py
+++ b/tests/test_rts_injection.py
@@ -40,6 +40,7 @@ def _rts_device(
 ) -> Device:
     """Create a minimal RTS Device for testing."""
     if commands is None:
+        # Realistic nparams values based on actual Overkiz API fixtures
         commands = [
             CommandDefinition(command_name="close", nparams=1),
             CommandDefinition(command_name="open", nparams=1),
@@ -47,13 +48,12 @@ def _rts_device(
             CommandDefinition(command_name="down", nparams=1),
             CommandDefinition(command_name="stop", nparams=1),
             CommandDefinition(command_name="my", nparams=1),
+            CommandDefinition(command_name="rest", nparams=1),
             CommandDefinition(command_name="identify", nparams=0),
-            CommandDefinition(command_name="off", nparams=0),
-            CommandDefinition(command_name="on", nparams=0),
-            CommandDefinition(command_name="onWithTimer", nparams=1),
             CommandDefinition(command_name="test", nparams=0),
-            CommandDefinition(command_name="tiltPositive", nparams=0),
-            CommandDefinition(command_name="tiltNegative", nparams=0),
+            CommandDefinition(command_name="tiltPositive", nparams=2),
+            CommandDefinition(command_name="tiltNegative", nparams=2),
+            CommandDefinition(command_name="moveOf", nparams=2),
         ]
     return Device(
         attributes=States(),
@@ -205,17 +205,13 @@ class TestBasicInjection:
 # ---------------------------------------------------------------------------
 
 
-class TestBlockedCommands:
-    """Commands that previously lived in COMMANDS_WITHOUT_DELAY.
-
-    These commands have nparams=0 in their definition, so the new nparams-based
-    approach correctly skips them without needing a hardcoded blocklist.
-    """
+class TestCommandsNotInjected:
+    """Commands that must NOT receive duration injection."""
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "command_name",
-        ["identify", "off", "on", "test", "tiltPositive", "tiltNegative"],
+        ["identify", "test"],
     )
     async def test_zero_nparams_commands_not_injected(self, client_rts_0, command_name):
         """Commands with nparams=0 do not get any duration appended."""
@@ -238,13 +234,19 @@ class TestBlockedCommands:
             )
 
     @pytest.mark.asyncio
-    async def test_on_with_timer_already_has_param_not_injected(self, client_rts_0):
-        """OnWithTimer has nparams=1 but user passes the timer value — no room for duration."""
+    @pytest.mark.parametrize(
+        "command_name",
+        ["tiltPositive", "tiltNegative", "moveOf"],
+    )
+    async def test_multi_nparams_commands_not_injected(
+        self, client_rts_0, command_name
+    ):
+        """Commands with nparams=2 (tilt, moveOf) have domain-specific params, not duration."""
         client_rts_0.devices = [_rts_device()]
 
         action = Action(
             device_url="rts://1234-5678-9012/1",
-            commands=[Command(name="onWithTimer", parameters=[60])],
+            commands=[Command(name=command_name)],
         )
 
         with patch.object(
@@ -254,16 +256,28 @@ class TestBlockedCommands:
             await client_rts_0.execute_action_group([action])
 
             called_actions = mock_exec.call_args[0][0]
-            assert called_actions[0].commands[0].parameters == [60]
+            assert called_actions[0].commands[0].parameters is None, (
+                f"Command '{command_name}' (nparams=2) should NOT get duration"
+            )
 
     @pytest.mark.asyncio
-    async def test_on_with_timer_no_param_gets_duration(self, client_rts_0):
-        """OnWithTimer with nparams=1 and no parameters yet gets duration injected."""
+    @pytest.mark.parametrize(
+        ("command_name", "params"),
+        [
+            ("tiltPositive", [1]),
+            ("tiltNegative", [15]),
+            ("moveOf", [50]),
+        ],
+    )
+    async def test_multi_nparams_commands_with_partial_params_not_injected(
+        self, client_rts_0, command_name, params
+    ):
+        """Commands with nparams=2 and 1 param filled still don't get injection."""
         client_rts_0.devices = [_rts_device()]
 
         action = Action(
             device_url="rts://1234-5678-9012/1",
-            commands=[Command(name="onWithTimer")],
+            commands=[Command(name=command_name, parameters=params)],
         )
 
         with patch.object(
@@ -273,7 +287,38 @@ class TestBlockedCommands:
             await client_rts_0.execute_action_group([action])
 
             called_actions = mock_exec.call_args[0][0]
-            assert called_actions[0].commands[0].parameters == [0]
+            assert called_actions[0].commands[0].parameters == params, (
+                f"Command '{command_name}' (nparams=2) should NOT get duration injected"
+            )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("command_name", "params"),
+        [
+            ("tiltPositive", [1, 0]),
+            ("tiltNegative", [15, 1]),
+            ("moveOf", [50, 100]),
+        ],
+    )
+    async def test_multi_nparams_commands_fully_filled_not_injected(
+        self, client_rts_0, command_name, params
+    ):
+        """Commands with nparams=2 and all params filled pass through unchanged."""
+        client_rts_0.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name=command_name, parameters=params)],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == params
 
 
 # ---------------------------------------------------------------------------
@@ -372,11 +417,11 @@ class TestSettingDisabled:
 
 
 class TestParameterCapacity:
-    """Tests verifying injection only when there's room (current_count < nparams)."""
+    """Tests verifying injection only for nparams=1 commands with 0 params."""
 
     @pytest.mark.asyncio
-    async def test_command_already_at_max_params_not_modified(self, client_rts_0):
-        """Command that already has nparams parameters is not modified."""
+    async def test_nparams_1_already_has_param_not_modified(self, client_rts_0):
+        """Command with nparams=1 that already has its parameter is not modified."""
         client_rts_0.devices = [_rts_device()]
 
         action = Action(
@@ -394,51 +439,7 @@ class TestParameterCapacity:
             assert called_actions[0].commands[0].parameters == [50]
 
     @pytest.mark.asyncio
-    async def test_command_with_multi_nparams(self, client_rts_0):
-        """Command with nparams=3 and 2 params already gets duration as 3rd param."""
-        device = _rts_device(
-            commands=[CommandDefinition(command_name="setClosure", nparams=3)]
-        )
-        client_rts_0.devices = [device]
-
-        action = Action(
-            device_url="rts://1234-5678-9012/1",
-            commands=[Command(name="setClosure", parameters=[50, 100])],
-        )
-
-        with patch.object(
-            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
-        ) as mock_exec:
-            mock_exec.return_value = "exec-123"
-            await client_rts_0.execute_action_group([action])
-
-            called_actions = mock_exec.call_args[0][0]
-            assert called_actions[0].commands[0].parameters == [50, 100, 0]
-
-    @pytest.mark.asyncio
-    async def test_command_at_nparams_capacity_not_modified(self, client_rts_0):
-        """Command with nparams=2 and already 2 params is not modified."""
-        device = _rts_device(
-            commands=[CommandDefinition(command_name="setClosure", nparams=2)]
-        )
-        client_rts_0.devices = [device]
-
-        action = Action(
-            device_url="rts://1234-5678-9012/1",
-            commands=[Command(name="setClosure", parameters=[50, 100])],
-        )
-
-        with patch.object(
-            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
-        ) as mock_exec:
-            mock_exec.return_value = "exec-123"
-            await client_rts_0.execute_action_group([action])
-
-            called_actions = mock_exec.call_args[0][0]
-            assert called_actions[0].commands[0].parameters == [50, 100]
-
-    @pytest.mark.asyncio
-    async def test_command_over_nparams_not_modified(self, client_rts_0):
+    async def test_nparams_1_with_extra_params_not_modified(self, client_rts_0):
         """Command that somehow has MORE params than nparams is not modified (defensive)."""
         device = _rts_device(
             commands=[CommandDefinition(command_name="close", nparams=1)]
@@ -477,6 +478,31 @@ class TestParameterCapacity:
 
             called_actions = mock_exec.call_args[0][0]
             assert called_actions[0].commands[0].parameters == [0]
+
+    @pytest.mark.asyncio
+    async def test_nparams_2_never_gets_injection(self, client_rts_0):
+        """Commands with nparams >= 2 never get injection regardless of param count."""
+        device = _rts_device(
+            commands=[CommandDefinition(command_name="setClosure", nparams=3)]
+        )
+        client_rts_0.devices = [device]
+
+        for params in [None, [], [50], [50, 100]]:
+            action = Action(
+                device_url="rts://1234-5678-9012/1",
+                commands=[Command(name="setClosure", parameters=params)],
+            )
+
+            with patch.object(
+                client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_exec.return_value = "exec-123"
+                await client_rts_0.execute_action_group([action])
+
+                called_actions = mock_exec.call_args[0][0]
+                assert called_actions[0].commands[0].parameters == params, (
+                    f"nparams=3 with params={params} should NOT be modified"
+                )
 
 
 # ---------------------------------------------------------------------------
@@ -781,14 +807,11 @@ class TestImmutability:
 
     @pytest.mark.asyncio
     async def test_original_parameters_list_not_mutated(self, client_rts_0):
-        """If command had existing params, original list is not modified."""
-        device = _rts_device(
-            commands=[CommandDefinition(command_name="setClosure", nparams=3)]
-        )
-        client_rts_0.devices = [device]
+        """If command had existing empty params list, original list is not modified."""
+        client_rts_0.devices = [_rts_device()]
 
-        original_params = [50, 100]
-        cmd = Command(name="setClosure", parameters=original_params)
+        original_params: list[int] = []
+        cmd = Command(name="close", parameters=original_params)
         action = Action(
             device_url="rts://1234-5678-9012/1",
             commands=[cmd],
@@ -801,11 +824,11 @@ class TestImmutability:
             await client_rts_0.execute_action_group([action])
 
             called_actions = mock_exec.call_args[0][0]
-            assert called_actions[0].commands[0].parameters == [50, 100, 0]
+            assert called_actions[0].commands[0].parameters == [0]
 
-        # Original list must still be [50, 100]
-        assert original_params == [50, 100]
-        assert cmd.parameters == [50, 100]
+        # Original list must still be empty
+        assert original_params == []
+        assert cmd.parameters == []
 
 
 # ---------------------------------------------------------------------------
@@ -814,53 +837,27 @@ class TestImmutability:
 
 
 class TestEquivalenceWithOldApproach:
-    """Verify nparams approach matches the old COMMANDS_WITHOUT_DELAY blocklist."""
+    """Verify the nparams=1 rule produces correct results for real RTS devices.
 
-    OLD_BLOCKLIST: frozenset[str] = frozenset(
-        {"identify", "off", "on", "onWithTimer", "test", "tiltPositive", "tiltNegative"}
-    )
-    MOVEMENT_COMMANDS: frozenset[str] = frozenset(
-        {"close", "open", "up", "down", "stop", "my"}
-    )
+    Based on actual Overkiz API fixture data (cloud_somfy_connexoon_rts_asia.json):
+    - Movement commands (close, open, up, down, stop, my, rest): nparams=1 -> GET duration
+    - Utility commands (identify, test): nparams=0 -> no injection
+    - Tilt/move commands (tiltPositive, tiltNegative, moveOf): nparams=2 -> no injection
+    - Some venetian blind devices have open/close/stop at nparams=0 -> no injection
 
-    @pytest.mark.asyncio
-    async def test_old_blocklist_commands_skipped(self, client_rts_0):
-        """Every command from the old COMMANDS_WITHOUT_DELAY list is NOT injected."""
-        client_rts_0.devices = [_rts_device()]
-
-        for cmd_name in self.OLD_BLOCKLIST:
-            action = Action(
-                device_url="rts://1234-5678-9012/1",
-                commands=[Command(name=cmd_name)],
-            )
-
-            with patch.object(
-                client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
-            ) as mock_exec:
-                mock_exec.return_value = "exec-123"
-                await client_rts_0.execute_action_group([action])
-
-                called_actions = mock_exec.call_args[0][0]
-                params = called_actions[0].commands[0].parameters
-                # onWithTimer has nparams=1, so it DOES get injection when sent without params.
-                # This is a deliberate behavioral difference from the old approach: the old
-                # approach blindly blocked it, but the new approach correctly handles it based
-                # on capacity. This is tested separately below.
-                if cmd_name == "onWithTimer":
-                    assert params == [0], (
-                        "onWithTimer (nparams=1, no params) gets injection in new approach"
-                    )
-                else:
-                    assert params is None, (
-                        f"'{cmd_name}' (nparams=0) must NOT get duration"
-                    )
+    The old COMMANDS_WITHOUT_DELAY blocklist (identify, off, on, onWithTimer,
+    test, tiltPositive, tiltNegative) is no longer needed because:
+    - identify, test: nparams=0 — naturally excluded
+    - tiltPositive, tiltNegative: nparams=2 — excluded by nparams==1 rule
+    - off, on, onWithTimer: don't exist on real RTS devices in the fixtures
+    """
 
     @pytest.mark.asyncio
     async def test_movement_commands_injected(self, client_rts_0):
-        """All typical movement commands (not in old blocklist) DO get injection."""
+        """All movement commands with nparams=1 get duration injected."""
         client_rts_0.devices = [_rts_device()]
 
-        for cmd_name in self.MOVEMENT_COMMANDS:
+        for cmd_name in ("close", "open", "up", "down", "stop", "my", "rest"):
             action = Action(
                 device_url="rts://1234-5678-9012/1",
                 commands=[Command(name=cmd_name)],
@@ -874,8 +871,72 @@ class TestEquivalenceWithOldApproach:
 
                 called_actions = mock_exec.call_args[0][0]
                 assert called_actions[0].commands[0].parameters == [0], (
-                    f"'{cmd_name}' must get duration=0"
+                    f"'{cmd_name}' (nparams=1) must get duration=0"
                 )
+
+    @pytest.mark.asyncio
+    async def test_tilt_commands_not_injected(self, client_rts_0):
+        """tiltPositive/tiltNegative have nparams=2 (position, speed) — not duration."""
+        client_rts_0.devices = [_rts_device()]
+
+        for cmd_name in ("tiltPositive", "tiltNegative", "moveOf"):
+            action = Action(
+                device_url="rts://1234-5678-9012/1",
+                commands=[Command(name=cmd_name)],
+            )
+
+            with patch.object(
+                client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_exec.return_value = "exec-123"
+                await client_rts_0.execute_action_group([action])
+
+                called_actions = mock_exec.call_args[0][0]
+                assert called_actions[0].commands[0].parameters is None, (
+                    f"'{cmd_name}' (nparams=2) must NOT get duration"
+                )
+
+    @pytest.mark.asyncio
+    async def test_venetian_blind_zero_nparams_device(self, client_rts_0):
+        """Some RTS venetian blinds have open/close/stop at nparams=0 — no injection."""
+        device = _rts_device(
+            commands=[
+                CommandDefinition(command_name="open", nparams=0),
+                CommandDefinition(command_name="close", nparams=0),
+                CommandDefinition(command_name="stop", nparams=0),
+                CommandDefinition(command_name="my", nparams=1),
+                CommandDefinition(command_name="tiltPositive", nparams=2),
+                CommandDefinition(command_name="tiltNegative", nparams=2),
+                CommandDefinition(command_name="identify", nparams=0),
+            ]
+        )
+        client_rts_0.devices = [device]
+
+        for cmd_name, expect_injection in [
+            ("open", False),
+            ("close", False),
+            ("stop", False),
+            ("my", True),
+            ("tiltPositive", False),
+            ("identify", False),
+        ]:
+            action = Action(
+                device_url="rts://1234-5678-9012/1",
+                commands=[Command(name=cmd_name)],
+            )
+
+            with patch.object(
+                client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_exec.return_value = "exec-123"
+                await client_rts_0.execute_action_group([action])
+
+                called_actions = mock_exec.call_args[0][0]
+                params = called_actions[0].commands[0].parameters
+                if expect_injection:
+                    assert params == [0], f"'{cmd_name}' should get duration"
+                else:
+                    assert params is None, f"'{cmd_name}' should NOT get duration"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rts_injection.py
+++ b/tests/test_rts_injection.py
@@ -122,7 +122,7 @@ async def client_rts_0() -> OverkizClient:
     return OverkizClient(
         server=Server.SOMFY_EUROPE,
         credentials=UsernamePasswordCredentials("user", "pass"),
-        settings=OverkizClientSettings(rts_command_duration=0),
+        settings=OverkizClientSettings(default_rts_command_duration=0),
     )
 
 
@@ -132,7 +132,7 @@ async def client_rts_5() -> OverkizClient:
     return OverkizClient(
         server=Server.SOMFY_EUROPE,
         credentials=UsernamePasswordCredentials("user", "pass"),
-        settings=OverkizClientSettings(rts_command_duration=5),
+        settings=OverkizClientSettings(default_rts_command_duration=5),
     )
 
 
@@ -361,7 +361,7 @@ class TestMultiParamInjection:
 
 
 class TestNonRtsProtocols:
-    """Non-RTS devices are never touched regardless of rts_command_duration."""
+    """Non-RTS devices are never touched regardless of default_rts_command_duration."""
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -375,7 +375,7 @@ class TestNonRtsProtocols:
     async def test_non_rts_device_not_modified(
         self, client_rts_0, device_factory, device_url
     ):
-        """IO and Z-Wave commands are never modified even with rts_command_duration set."""
+        """IO and Z-Wave commands are never modified even with default_rts_command_duration set."""
         client_rts_0.devices = [device_factory()]
 
         action = Action(
@@ -394,12 +394,12 @@ class TestNonRtsProtocols:
 
 
 # ---------------------------------------------------------------------------
-# Setting disabled (rts_command_duration=None)
+# Setting disabled (default_rts_command_duration=None)
 # ---------------------------------------------------------------------------
 
 
 class TestSettingDisabled:
-    """When rts_command_duration is None (default), no injection occurs."""
+    """When default_rts_command_duration is None (default), no injection occurs."""
 
     @pytest.mark.asyncio
     async def test_no_setting_means_no_injection(self, client_no_rts):
@@ -1036,7 +1036,7 @@ class TestApplyRtsDurationDirect:
     """Direct unit tests on _apply_rts_duration without execute_action_group overhead."""
 
     def test_returns_same_list_when_setting_none(self, client_no_rts):
-        """Early return when rts_command_duration is None."""
+        """Early return when default_rts_command_duration is None."""
         client_no_rts.devices = [_rts_device()]
         actions = [
             Action(

--- a/tests/test_rts_injection.py
+++ b/tests/test_rts_injection.py
@@ -1,5 +1,13 @@
 # tests/test_rts_injection.py
-"""Tests for RTS command duration injection in execute_action_group."""
+"""Tests for RTS command duration injection in execute_action_group.
+
+This feature replaces the old COMMANDS_WITHOUT_DELAY blocklist approach that
+was used in the Home Assistant overkiz executor. The old approach blindly
+appended 0 to all RTS commands except a hardcoded list (identify, off, on,
+onWithTimer, test, tiltPositive, tiltNegative). The new approach uses the
+device's command definition nparams to decide whether a duration parameter
+can be added — this is more correct and future-proof.
+"""
 
 from __future__ import annotations
 
@@ -21,6 +29,10 @@ from pyoverkiz.models import (
     States,
 )
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
 
 def _rts_device(
     device_url: str = "rts://1234-5678-9012/1",
@@ -31,7 +43,17 @@ def _rts_device(
         commands = [
             CommandDefinition(command_name="close", nparams=1),
             CommandDefinition(command_name="open", nparams=1),
+            CommandDefinition(command_name="up", nparams=1),
+            CommandDefinition(command_name="down", nparams=1),
+            CommandDefinition(command_name="stop", nparams=1),
+            CommandDefinition(command_name="my", nparams=1),
             CommandDefinition(command_name="identify", nparams=0),
+            CommandDefinition(command_name="off", nparams=0),
+            CommandDefinition(command_name="on", nparams=0),
+            CommandDefinition(command_name="onWithTimer", nparams=1),
+            CommandDefinition(command_name="test", nparams=0),
+            CommandDefinition(command_name="tiltPositive", nparams=0),
+            CommandDefinition(command_name="tiltNegative", nparams=0),
         ]
     return Device(
         attributes=States(),
@@ -69,9 +91,34 @@ def _io_device(device_url: str = "io://1234-5678-9012/2") -> Device:
     )
 
 
+def _zwave_device(device_url: str = "zwave://1234-5678-9012/3") -> Device:
+    """Create a minimal Z-Wave device for testing."""
+    return Device(
+        attributes=States(),
+        available=True,
+        enabled=True,
+        label="ZWave Blind",
+        device_url=device_url,
+        controllable_name="zwave:blind",
+        definition=Definition(
+            commands=CommandDefinitions(
+                [CommandDefinition(command_name="close", nparams=1)]
+            ),
+            widget_name="SomeWidget",
+            ui_class="RollerShutter",
+        ),
+        type=ProductType.ACTUATOR,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
 @pytest_asyncio.fixture
-async def client_with_rts() -> OverkizClient:
-    """Client with RTS duration enabled."""
+async def client_rts_0() -> OverkizClient:
+    """Client with RTS duration=0 (most common HA config)."""
     return OverkizClient(
         server=Server.SOMFY_EUROPE,
         credentials=UsernamePasswordCredentials("user", "pass"),
@@ -80,182 +127,825 @@ async def client_with_rts() -> OverkizClient:
 
 
 @pytest_asyncio.fixture
-async def client_without_rts() -> OverkizClient:
-    """Client without RTS duration (default behavior)."""
+async def client_rts_5() -> OverkizClient:
+    """Client with RTS duration=5 (custom delay)."""
+    return OverkizClient(
+        server=Server.SOMFY_EUROPE,
+        credentials=UsernamePasswordCredentials("user", "pass"),
+        settings=OverkizClientSettings(rts_command_duration=5),
+    )
+
+
+@pytest_asyncio.fixture
+async def client_no_rts() -> OverkizClient:
+    """Client without RTS duration (default/passive)."""
     return OverkizClient(
         server=Server.SOMFY_EUROPE,
         credentials=UsernamePasswordCredentials("user", "pass"),
     )
 
 
-@pytest.mark.asyncio
-async def test_rts_device_gets_duration_appended(client_with_rts):
-    """RTS device command with room for extra param gets duration appended."""
-    client_with_rts.devices = [_rts_device()]
+# ---------------------------------------------------------------------------
+# Basic injection tests
+# ---------------------------------------------------------------------------
 
-    action = Action(
-        device_url="rts://1234-5678-9012/1",
-        commands=[Command(name="close")],
+
+class TestBasicInjection:
+    """Core tests: commands that accept a duration get it injected."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "command_name",
+        ["close", "open", "up", "down", "stop", "my"],
+    )
+    async def test_movement_commands_get_duration_injected(
+        self, client_rts_0, command_name
+    ):
+        """Movement commands (nparams=1, no params yet) get duration appended."""
+        client_rts_0.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name=command_name)],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [0], (
+                f"Command '{command_name}' should have gotten duration=0 appended"
+            )
+
+    @pytest.mark.asyncio
+    async def test_custom_duration_value_injected(self, client_rts_5):
+        """A non-zero duration is injected correctly."""
+        client_rts_5.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name="close")],
+        )
+
+        with patch.object(
+            client_rts_5, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_5.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [5]
+
+
+# ---------------------------------------------------------------------------
+# Commands that should NOT get injection (old COMMANDS_WITHOUT_DELAY list)
+# ---------------------------------------------------------------------------
+
+
+class TestBlockedCommands:
+    """Commands that previously lived in COMMANDS_WITHOUT_DELAY.
+
+    These commands have nparams=0 in their definition, so the new nparams-based
+    approach correctly skips them without needing a hardcoded blocklist.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "command_name",
+        ["identify", "off", "on", "test", "tiltPositive", "tiltNegative"],
+    )
+    async def test_zero_nparams_commands_not_injected(self, client_rts_0, command_name):
+        """Commands with nparams=0 do not get any duration appended."""
+        client_rts_0.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name=command_name)],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters is None, (
+                f"Command '{command_name}' (nparams=0) should NOT get duration"
+            )
+
+    @pytest.mark.asyncio
+    async def test_on_with_timer_already_has_param_not_injected(self, client_rts_0):
+        """OnWithTimer has nparams=1 but user passes the timer value — no room for duration."""
+        client_rts_0.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name="onWithTimer", parameters=[60])],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [60]
+
+    @pytest.mark.asyncio
+    async def test_on_with_timer_no_param_gets_duration(self, client_rts_0):
+        """OnWithTimer with nparams=1 and no parameters yet gets duration injected."""
+        client_rts_0.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name="onWithTimer")],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [0]
+
+
+# ---------------------------------------------------------------------------
+# Non-RTS protocols should never be modified
+# ---------------------------------------------------------------------------
+
+
+class TestNonRtsProtocols:
+    """Non-RTS devices are never touched regardless of rts_command_duration."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("device_factory", "device_url"),
+        [
+            (_io_device, "io://1234-5678-9012/2"),
+            (_zwave_device, "zwave://1234-5678-9012/3"),
+        ],
+        ids=["io", "zwave"],
+    )
+    async def test_non_rts_device_not_modified(
+        self, client_rts_0, device_factory, device_url
+    ):
+        """IO and Z-Wave commands are never modified even with rts_command_duration set."""
+        client_rts_0.devices = [device_factory()]
+
+        action = Action(
+            device_url=device_url,
+            commands=[Command(name="close")],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters is None
+
+
+# ---------------------------------------------------------------------------
+# Setting disabled (rts_command_duration=None)
+# ---------------------------------------------------------------------------
+
+
+class TestSettingDisabled:
+    """When rts_command_duration is None (default), no injection occurs."""
+
+    @pytest.mark.asyncio
+    async def test_no_setting_means_no_injection(self, client_no_rts):
+        """RTS device commands pass through unmodified when setting is None."""
+        client_no_rts.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name="close")],
+        )
+
+        with patch.object(
+            client_no_rts, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_no_rts.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters is None
+
+    @pytest.mark.asyncio
+    async def test_no_setting_multiple_rts_commands_unmodified(self, client_no_rts):
+        """Multiple RTS commands all pass through when setting is None."""
+        client_no_rts.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[
+                Command(name="close"),
+                Command(name="open"),
+                Command(name="my"),
+            ],
+        )
+
+        with patch.object(
+            client_no_rts, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_no_rts.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            for cmd in called_actions[0].commands:
+                assert cmd.parameters is None
+
+
+# ---------------------------------------------------------------------------
+# Parameter capacity tests
+# ---------------------------------------------------------------------------
+
+
+class TestParameterCapacity:
+    """Tests verifying injection only when there's room (current_count < nparams)."""
+
+    @pytest.mark.asyncio
+    async def test_command_already_at_max_params_not_modified(self, client_rts_0):
+        """Command that already has nparams parameters is not modified."""
+        client_rts_0.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name="close", parameters=[50])],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [50]
+
+    @pytest.mark.asyncio
+    async def test_command_with_multi_nparams(self, client_rts_0):
+        """Command with nparams=3 and 2 params already gets duration as 3rd param."""
+        device = _rts_device(
+            commands=[CommandDefinition(command_name="setClosure", nparams=3)]
+        )
+        client_rts_0.devices = [device]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name="setClosure", parameters=[50, 100])],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [50, 100, 0]
+
+    @pytest.mark.asyncio
+    async def test_command_at_nparams_capacity_not_modified(self, client_rts_0):
+        """Command with nparams=2 and already 2 params is not modified."""
+        device = _rts_device(
+            commands=[CommandDefinition(command_name="setClosure", nparams=2)]
+        )
+        client_rts_0.devices = [device]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name="setClosure", parameters=[50, 100])],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [50, 100]
+
+    @pytest.mark.asyncio
+    async def test_command_over_nparams_not_modified(self, client_rts_0):
+        """Command that somehow has MORE params than nparams is not modified (defensive)."""
+        device = _rts_device(
+            commands=[CommandDefinition(command_name="close", nparams=1)]
+        )
+        client_rts_0.devices = [device]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name="close", parameters=[10, 20])],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [10, 20]
+
+    @pytest.mark.asyncio
+    async def test_empty_parameters_list_counts_as_zero(self, client_rts_0):
+        """Explicit empty list [] counts as 0 params — duration gets appended."""
+        client_rts_0.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name="close", parameters=[])],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [0]
+
+
+# ---------------------------------------------------------------------------
+# Multi-command and multi-action tests
+# ---------------------------------------------------------------------------
+
+
+class TestMultiCommandActions:
+    """Tests for actions with multiple commands."""
+
+    @pytest.mark.asyncio
+    async def test_mixed_commands_in_single_action(self, client_rts_0):
+        """Action with injectable and non-injectable commands handles each correctly."""
+        client_rts_0.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[
+                Command(name="close"),  # nparams=1, no params -> inject
+                Command(name="identify"),  # nparams=0 -> skip
+                Command(name="open", parameters=[50]),  # nparams=1, full -> skip
+                Command(name="up"),  # nparams=1, no params -> inject
+            ],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            cmds = mock_exec.call_args[0][0][0].commands
+            assert cmds[0].parameters == [0]  # close: injected
+            assert cmds[1].parameters is None  # identify: skipped
+            assert cmds[2].parameters == [50]  # open: already full
+            assert cmds[3].parameters == [0]  # up: injected
+
+    @pytest.mark.asyncio
+    async def test_multiple_actions_mixed_protocols(self, client_rts_0):
+        """Multiple actions in one call: RTS gets injection, IO does not."""
+        rts = _rts_device()
+        io = _io_device()
+        client_rts_0.devices = [rts, io]
+
+        actions = [
+            Action(
+                device_url="rts://1234-5678-9012/1",
+                commands=[Command(name="close")],
+            ),
+            Action(
+                device_url="io://1234-5678-9012/2",
+                commands=[Command(name="close")],
+            ),
+        ]
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group(actions)
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [0]  # RTS
+            assert called_actions[1].commands[0].parameters is None  # IO
+
+    @pytest.mark.asyncio
+    async def test_multiple_rts_actions(self, client_rts_0):
+        """Multiple RTS actions all get duration injected independently."""
+        rts1 = _rts_device(device_url="rts://1234-5678-9012/1")
+        rts2 = _rts_device(device_url="rts://1234-5678-9012/4")
+        client_rts_0.devices = [rts1, rts2]
+
+        actions = [
+            Action(
+                device_url="rts://1234-5678-9012/1",
+                commands=[Command(name="close")],
+            ),
+            Action(
+                device_url="rts://1234-5678-9012/4",
+                commands=[Command(name="open")],
+            ),
+        ]
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group(actions)
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [0]
+            assert called_actions[1].commands[0].parameters == [0]
+
+
+# ---------------------------------------------------------------------------
+# Device URL edge cases (subsystem IDs)
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceUrlEdgeCases:
+    """RTS devices with subsystem IDs (e.g., rts://gateway/addr#2)."""
+
+    @pytest.mark.asyncio
+    async def test_rts_device_with_subsystem_id(self, client_rts_0):
+        """RTS device with subsystem ID (#2) gets injection."""
+        device = _rts_device(device_url="rts://1234-5678-9012/1#2")
+        client_rts_0.devices = [device]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1#2",
+            commands=[Command(name="close")],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [0]
+
+    @pytest.mark.asyncio
+    async def test_mismatched_subsystem_id_not_found(self, client_rts_0):
+        """Action URL rts://...#2 but devices only has rts://...#1 => not found, skip."""
+        device = _rts_device(device_url="rts://1234-5678-9012/1#1")
+        client_rts_0.devices = [device]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1#2",
+            commands=[Command(name="close")],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters is None
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation / robustness
+# ---------------------------------------------------------------------------
+
+
+class TestRobustness:
+    """Edge cases and error scenarios that must not crash."""
+
+    @pytest.mark.asyncio
+    async def test_device_not_in_devices_list(self, client_rts_0):
+        """Action for unknown device URL passes through without crashing."""
+        client_rts_0.devices = []
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name="close")],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters is None
+
+    @pytest.mark.asyncio
+    async def test_command_not_in_definitions(self, client_rts_0):
+        """RTS device exists but command not in its definitions — skip injection."""
+        device = _rts_device(
+            commands=[CommandDefinition(command_name="close", nparams=1)]
+        )
+        client_rts_0.devices = [device]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name="unknownCommand")],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters is None
+
+    @pytest.mark.asyncio
+    async def test_empty_command_definitions(self, client_rts_0):
+        """RTS device with no command definitions at all — skip gracefully."""
+        device = Device(
+            attributes=States(),
+            available=True,
+            enabled=True,
+            label="RTS No Defs",
+            device_url="rts://1234-5678-9012/1",
+            controllable_name="rts:blind",
+            definition=Definition(widget_name="SomeWidget", ui_class="RollerShutter"),
+            type=ProductType.ACTUATOR,
+        )
+        client_rts_0.devices = [device]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name="close")],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters is None
+
+    @pytest.mark.asyncio
+    async def test_empty_actions_list(self, client_rts_0):
+        """Empty actions list does not crash."""
+        client_rts_0.devices = [_rts_device()]
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions == []
+
+    @pytest.mark.asyncio
+    async def test_action_with_empty_commands_list(self, client_rts_0):
+        """Action with no commands passes through without crash."""
+        client_rts_0.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands == []
+
+
+# ---------------------------------------------------------------------------
+# Immutability / side-effect tests
+# ---------------------------------------------------------------------------
+
+
+class TestImmutability:
+    """Verify that injection does not mutate original objects."""
+
+    @pytest.mark.asyncio
+    async def test_original_command_not_mutated(self, client_rts_0):
+        """Injection creates new Command; original Command is untouched."""
+        client_rts_0.devices = [_rts_device()]
+
+        original_cmd = Command(name="close")
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[original_cmd],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+        assert original_cmd.parameters is None
+
+    @pytest.mark.asyncio
+    async def test_original_action_not_mutated(self, client_rts_0):
+        """Original action list is not modified in place."""
+        client_rts_0.devices = [_rts_device()]
+
+        cmd = Command(name="close")
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[cmd],
+        )
+        original_actions = [action]
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group(original_actions)
+
+        assert original_actions[0].commands[0].parameters is None
+
+    @pytest.mark.asyncio
+    async def test_original_parameters_list_not_mutated(self, client_rts_0):
+        """If command had existing params, original list is not modified."""
+        device = _rts_device(
+            commands=[CommandDefinition(command_name="setClosure", nparams=3)]
+        )
+        client_rts_0.devices = [device]
+
+        original_params = [50, 100]
+        cmd = Command(name="setClosure", parameters=original_params)
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[cmd],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [50, 100, 0]
+
+        # Original list must still be [50, 100]
+        assert original_params == [50, 100]
+        assert cmd.parameters == [50, 100]
+
+
+# ---------------------------------------------------------------------------
+# Behavioral equivalence with old COMMANDS_WITHOUT_DELAY approach
+# ---------------------------------------------------------------------------
+
+
+class TestEquivalenceWithOldApproach:
+    """Verify nparams approach matches the old COMMANDS_WITHOUT_DELAY blocklist."""
+
+    OLD_BLOCKLIST: frozenset[str] = frozenset(
+        {"identify", "off", "on", "onWithTimer", "test", "tiltPositive", "tiltNegative"}
+    )
+    MOVEMENT_COMMANDS: frozenset[str] = frozenset(
+        {"close", "open", "up", "down", "stop", "my"}
     )
 
-    with patch.object(
-        client_with_rts, "_execute_action_group_direct", new_callable=AsyncMock
-    ) as mock_exec:
-        mock_exec.return_value = "exec-123"
-        await client_with_rts.execute_action_group([action])
+    @pytest.mark.asyncio
+    async def test_old_blocklist_commands_skipped(self, client_rts_0):
+        """Every command from the old COMMANDS_WITHOUT_DELAY list is NOT injected."""
+        client_rts_0.devices = [_rts_device()]
 
-        called_actions = mock_exec.call_args[0][0]
-        assert called_actions[0].commands[0].parameters == [0]
+        for cmd_name in self.OLD_BLOCKLIST:
+            action = Action(
+                device_url="rts://1234-5678-9012/1",
+                commands=[Command(name=cmd_name)],
+            )
 
+            with patch.object(
+                client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_exec.return_value = "exec-123"
+                await client_rts_0.execute_action_group([action])
 
-@pytest.mark.asyncio
-async def test_rts_command_already_has_max_params_not_modified(client_with_rts):
-    """RTS command that already has nparams parameters is not modified."""
-    client_with_rts.devices = [_rts_device()]
+                called_actions = mock_exec.call_args[0][0]
+                params = called_actions[0].commands[0].parameters
+                # onWithTimer has nparams=1, so it DOES get injection when sent without params.
+                # This is a deliberate behavioral difference from the old approach: the old
+                # approach blindly blocked it, but the new approach correctly handles it based
+                # on capacity. This is tested separately below.
+                if cmd_name == "onWithTimer":
+                    assert params == [0], (
+                        "onWithTimer (nparams=1, no params) gets injection in new approach"
+                    )
+                else:
+                    assert params is None, (
+                        f"'{cmd_name}' (nparams=0) must NOT get duration"
+                    )
 
-    action = Action(
-        device_url="rts://1234-5678-9012/1",
-        commands=[Command(name="close", parameters=[50])],
-    )
+    @pytest.mark.asyncio
+    async def test_movement_commands_injected(self, client_rts_0):
+        """All typical movement commands (not in old blocklist) DO get injection."""
+        client_rts_0.devices = [_rts_device()]
 
-    with patch.object(
-        client_with_rts, "_execute_action_group_direct", new_callable=AsyncMock
-    ) as mock_exec:
-        mock_exec.return_value = "exec-123"
-        await client_with_rts.execute_action_group([action])
+        for cmd_name in self.MOVEMENT_COMMANDS:
+            action = Action(
+                device_url="rts://1234-5678-9012/1",
+                commands=[Command(name=cmd_name)],
+            )
 
-        called_actions = mock_exec.call_args[0][0]
-        # nparams=1 and already has 1 param — should NOT add another
-        assert called_actions[0].commands[0].parameters == [50]
+            with patch.object(
+                client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_exec.return_value = "exec-123"
+                await client_rts_0.execute_action_group([action])
 
-
-@pytest.mark.asyncio
-async def test_rts_command_with_zero_nparams_not_modified(client_with_rts):
-    """RTS command with nparams=0 (e.g., identify) is not modified."""
-    client_with_rts.devices = [_rts_device()]
-
-    action = Action(
-        device_url="rts://1234-5678-9012/1",
-        commands=[Command(name="identify")],
-    )
-
-    with patch.object(
-        client_with_rts, "_execute_action_group_direct", new_callable=AsyncMock
-    ) as mock_exec:
-        mock_exec.return_value = "exec-123"
-        await client_with_rts.execute_action_group([action])
-
-        called_actions = mock_exec.call_args[0][0]
-        assert called_actions[0].commands[0].parameters is None
-
-
-@pytest.mark.asyncio
-async def test_io_device_not_modified(client_with_rts):
-    """Non-RTS device commands are never modified, even with rts_command_duration set."""
-    client_with_rts.devices = [_io_device()]
-
-    action = Action(
-        device_url="io://1234-5678-9012/2",
-        commands=[Command(name="close")],
-    )
-
-    with patch.object(
-        client_with_rts, "_execute_action_group_direct", new_callable=AsyncMock
-    ) as mock_exec:
-        mock_exec.return_value = "exec-123"
-        await client_with_rts.execute_action_group([action])
-
-        called_actions = mock_exec.call_args[0][0]
-        assert called_actions[0].commands[0].parameters is None
+                called_actions = mock_exec.call_args[0][0]
+                assert called_actions[0].commands[0].parameters == [0], (
+                    f"'{cmd_name}' must get duration=0"
+                )
 
 
-@pytest.mark.asyncio
-async def test_no_rts_setting_means_no_injection(client_without_rts):
-    """When rts_command_duration is None, no injection happens for any device."""
-    client_without_rts.devices = [_rts_device()]
-
-    action = Action(
-        device_url="rts://1234-5678-9012/1",
-        commands=[Command(name="close")],
-    )
-
-    with patch.object(
-        client_without_rts, "_execute_action_group_direct", new_callable=AsyncMock
-    ) as mock_exec:
-        mock_exec.return_value = "exec-123"
-        await client_without_rts.execute_action_group([action])
-
-        called_actions = mock_exec.call_args[0][0]
-        assert called_actions[0].commands[0].parameters is None
+# ---------------------------------------------------------------------------
+# Unit test for _apply_rts_duration directly (fast, no mock overhead)
+# ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_rts_device_not_in_devices_list_skipped(client_with_rts):
-    """If device URL is not in client.devices, skip injection (no crash)."""
-    client_with_rts.devices = []  # No devices loaded
+class TestApplyRtsDurationDirect:
+    """Direct unit tests on _apply_rts_duration without execute_action_group overhead."""
 
-    action = Action(
-        device_url="rts://1234-5678-9012/1",
-        commands=[Command(name="close")],
-    )
+    def test_returns_same_list_when_setting_none(self, client_no_rts):
+        """Early return when rts_command_duration is None."""
+        client_no_rts.devices = [_rts_device()]
+        actions = [
+            Action(
+                device_url="rts://1234-5678-9012/1",
+                commands=[Command(name="close")],
+            )
+        ]
 
-    with patch.object(
-        client_with_rts, "_execute_action_group_direct", new_callable=AsyncMock
-    ) as mock_exec:
-        mock_exec.return_value = "exec-123"
-        await client_with_rts.execute_action_group([action])
+        result = client_no_rts._apply_rts_duration(actions)
+        assert result is actions  # Same object, not a copy
 
-        called_actions = mock_exec.call_args[0][0]
-        # Not modified — device not found, so we can't know nparams
-        assert called_actions[0].commands[0].parameters is None
+    def test_rts_injection_basic(self, client_rts_0):
+        """Direct call: RTS close with nparams=1 and no params."""
+        client_rts_0.devices = [_rts_device()]
+        actions = [
+            Action(
+                device_url="rts://1234-5678-9012/1",
+                commands=[Command(name="close")],
+            )
+        ]
 
+        result = client_rts_0._apply_rts_duration(actions)
+        assert result[0].commands[0].parameters == [0]
 
-@pytest.mark.asyncio
-async def test_rts_device_without_command_definitions_skipped(client_with_rts):
-    """RTS device without command definitions doesn't crash, just skips injection."""
-    device = Device(
-        attributes=States(),
-        available=True,
-        enabled=True,
-        label="RTS No Def",
-        device_url="rts://1234-5678-9012/1",
-        controllable_name="rts:blind",
-        definition=Definition(widget_name="SomeWidget", ui_class="RollerShutter"),
-        type=ProductType.ACTUATOR,
-    )
-    client_with_rts.devices = [device]
+    def test_preserves_command_type(self, client_rts_0):
+        """The type field on a Command is preserved through injection."""
+        client_rts_0.devices = [_rts_device()]
+        actions = [
+            Action(
+                device_url="rts://1234-5678-9012/1",
+                commands=[Command(name="close", type=1)],
+            )
+        ]
 
-    action = Action(
-        device_url="rts://1234-5678-9012/1",
-        commands=[Command(name="close")],
-    )
+        result = client_rts_0._apply_rts_duration(actions)
+        assert result[0].commands[0].type == 1
+        assert result[0].commands[0].parameters == [0]
 
-    with patch.object(
-        client_with_rts, "_execute_action_group_direct", new_callable=AsyncMock
-    ) as mock_exec:
-        mock_exec.return_value = "exec-123"
-        await client_with_rts.execute_action_group([action])
+    def test_multiple_devices_in_single_batch(self, client_rts_0):
+        """Batch with two RTS devices and one IO."""
+        rts1 = _rts_device(device_url="rts://1234-5678-9012/1")
+        rts2 = _rts_device(device_url="rts://1234-5678-9012/5")
+        io = _io_device()
+        client_rts_0.devices = [rts1, rts2, io]
 
-        called_actions = mock_exec.call_args[0][0]
-        assert called_actions[0].commands[0].parameters is None
+        actions = [
+            Action(
+                device_url="rts://1234-5678-9012/1", commands=[Command(name="close")]
+            ),
+            Action(
+                device_url="io://1234-5678-9012/2", commands=[Command(name="close")]
+            ),
+            Action(
+                device_url="rts://1234-5678-9012/5", commands=[Command(name="open")]
+            ),
+        ]
 
-
-@pytest.mark.asyncio
-async def test_original_action_not_mutated(client_with_rts):
-    """Injection creates new Command objects; original actions are not mutated."""
-    client_with_rts.devices = [_rts_device()]
-
-    original_cmd = Command(name="close")
-    action = Action(
-        device_url="rts://1234-5678-9012/1",
-        commands=[original_cmd],
-    )
-
-    with patch.object(
-        client_with_rts, "_execute_action_group_direct", new_callable=AsyncMock
-    ) as mock_exec:
-        mock_exec.return_value = "exec-123"
-        await client_with_rts.execute_action_group([action])
-
-    # Original command should NOT have been mutated
-    assert original_cmd.parameters is None
+        result = client_rts_0._apply_rts_duration(actions)
+        assert result[0].commands[0].parameters == [0]
+        assert result[1].commands[0].parameters is None
+        assert result[2].commands[0].parameters == [0]

--- a/tests/test_rts_injection.py
+++ b/tests/test_rts_injection.py
@@ -238,10 +238,10 @@ class TestCommandsNotInjected:
         "command_name",
         ["tiltPositive", "tiltNegative", "moveOf"],
     )
-    async def test_multi_nparams_commands_not_injected(
+    async def test_multi_nparams_no_params_not_injected(
         self, client_rts_0, command_name
     ):
-        """Commands with nparams=2 (tilt, moveOf) have domain-specific params, not duration."""
+        """nparams=2 commands with 0 params: position not yet provided, no injection."""
         client_rts_0.devices = [_rts_device()]
 
         action = Action(
@@ -257,38 +257,7 @@ class TestCommandsNotInjected:
 
             called_actions = mock_exec.call_args[0][0]
             assert called_actions[0].commands[0].parameters is None, (
-                f"Command '{command_name}' (nparams=2) should NOT get duration"
-            )
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        ("command_name", "params"),
-        [
-            ("tiltPositive", [1]),
-            ("tiltNegative", [15]),
-            ("moveOf", [50]),
-        ],
-    )
-    async def test_multi_nparams_commands_with_partial_params_not_injected(
-        self, client_rts_0, command_name, params
-    ):
-        """Commands with nparams=2 and 1 param filled still don't get injection."""
-        client_rts_0.devices = [_rts_device()]
-
-        action = Action(
-            device_url="rts://1234-5678-9012/1",
-            commands=[Command(name=command_name, parameters=params)],
-        )
-
-        with patch.object(
-            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
-        ) as mock_exec:
-            mock_exec.return_value = "exec-123"
-            await client_rts_0.execute_action_group([action])
-
-            called_actions = mock_exec.call_args[0][0]
-            assert called_actions[0].commands[0].parameters == params, (
-                f"Command '{command_name}' (nparams=2) should NOT get duration injected"
+                f"Command '{command_name}' with 0 params should NOT get duration"
             )
 
     @pytest.mark.asyncio
@@ -297,13 +266,13 @@ class TestCommandsNotInjected:
         [
             ("tiltPositive", [1, 0]),
             ("tiltNegative", [15, 1]),
-            ("moveOf", [50, 100]),
+            ("moveOf", [50, 10]),
         ],
     )
-    async def test_multi_nparams_commands_fully_filled_not_injected(
+    async def test_multi_nparams_fully_filled_not_injected(
         self, client_rts_0, command_name, params
     ):
-        """Commands with nparams=2 and all params filled pass through unchanged."""
+        """nparams=2 commands already at capacity pass through unchanged."""
         client_rts_0.devices = [_rts_device()]
 
         action = Action(
@@ -319,6 +288,71 @@ class TestCommandsNotInjected:
 
             called_actions = mock_exec.call_args[0][0]
             assert called_actions[0].commands[0].parameters == params
+
+
+# ---------------------------------------------------------------------------
+# Multi-param commands that DO get injection (last param = duration)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiParamInjection:
+    """Commands with nparams=2 where position is provided and duration slot is empty.
+
+    Per Overkiz API docs, the last parameter is always the execution duration:
+    - tiltPositive: p1=position [0..127], p2=duration [0..15] (default 15)
+    - tiltNegative: p1=position [0..127], p2=duration [0..15] (default 15)
+    - moveOf: p1=position [-127..127], p2=duration [0..15]
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("command_name", "position_param"),
+        [
+            ("tiltPositive", [1]),
+            ("tiltNegative", [15]),
+            ("moveOf", [50]),
+        ],
+    )
+    async def test_multi_nparams_with_position_gets_duration(
+        self, client_rts_0, command_name, position_param
+    ):
+        """nparams=2 with 1 param filled: last slot is duration, inject it."""
+        client_rts_0.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name=command_name, parameters=position_param)],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [*position_param, 0], (
+                f"Command '{command_name}' with position should get duration appended"
+            )
+
+    @pytest.mark.asyncio
+    async def test_tilt_with_custom_duration(self, client_rts_5):
+        """Custom duration value (5) is injected into tilt command."""
+        client_rts_5.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name="tiltPositive", parameters=[100])],
+        )
+
+        with patch.object(
+            client_rts_5, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_5.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [100, 5]
 
 
 # ---------------------------------------------------------------------------
@@ -417,11 +451,11 @@ class TestSettingDisabled:
 
 
 class TestParameterCapacity:
-    """Tests verifying injection only for nparams=1 commands with 0 params."""
+    """Tests verifying injection only when current_count == nparams - 1."""
 
     @pytest.mark.asyncio
     async def test_nparams_1_already_has_param_not_modified(self, client_rts_0):
-        """Command with nparams=1 that already has its parameter is not modified."""
+        """Command with nparams=1 that already has its duration is not modified."""
         client_rts_0.devices = [_rts_device()]
 
         action = Action(
@@ -480,29 +514,61 @@ class TestParameterCapacity:
             assert called_actions[0].commands[0].parameters == [0]
 
     @pytest.mark.asyncio
-    async def test_nparams_2_never_gets_injection(self, client_rts_0):
-        """Commands with nparams >= 2 never get injection regardless of param count."""
-        device = _rts_device(
-            commands=[CommandDefinition(command_name="setClosure", nparams=3)]
+    async def test_nparams_2_with_0_params_not_injected(self, client_rts_0):
+        """nparams=2 with 0 params: not at nparams-1, no injection."""
+        client_rts_0.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name="tiltPositive")],
         )
-        client_rts_0.devices = [device]
 
-        for params in [None, [], [50], [50, 100]]:
-            action = Action(
-                device_url="rts://1234-5678-9012/1",
-                commands=[Command(name="setClosure", parameters=params)],
-            )
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
 
-            with patch.object(
-                client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
-            ) as mock_exec:
-                mock_exec.return_value = "exec-123"
-                await client_rts_0.execute_action_group([action])
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters is None
 
-                called_actions = mock_exec.call_args[0][0]
-                assert called_actions[0].commands[0].parameters == params, (
-                    f"nparams=3 with params={params} should NOT be modified"
-                )
+    @pytest.mark.asyncio
+    async def test_nparams_2_with_1_param_gets_injection(self, client_rts_0):
+        """nparams=2 with 1 param: at nparams-1, duration injected as last param."""
+        client_rts_0.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name="tiltPositive", parameters=[50])],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [50, 0]
+
+    @pytest.mark.asyncio
+    async def test_nparams_2_with_2_params_not_injected(self, client_rts_0):
+        """nparams=2 with 2 params: already at capacity, no injection."""
+        client_rts_0.devices = [_rts_device()]
+
+        action = Action(
+            device_url="rts://1234-5678-9012/1",
+            commands=[Command(name="tiltPositive", parameters=[50, 5])],
+        )
+
+        with patch.object(
+            client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+        ) as mock_exec:
+            mock_exec.return_value = "exec-123"
+            await client_rts_0.execute_action_group([action])
+
+            called_actions = mock_exec.call_args[0][0]
+            assert called_actions[0].commands[0].parameters == [50, 5]
 
 
 # ---------------------------------------------------------------------------
@@ -807,11 +873,11 @@ class TestImmutability:
 
     @pytest.mark.asyncio
     async def test_original_parameters_list_not_mutated(self, client_rts_0):
-        """If command had existing empty params list, original list is not modified."""
+        """Original parameters list on a multi-param command is not modified."""
         client_rts_0.devices = [_rts_device()]
 
-        original_params: list[int] = []
-        cmd = Command(name="close", parameters=original_params)
+        original_params = [50]
+        cmd = Command(name="tiltPositive", parameters=original_params)
         action = Action(
             device_url="rts://1234-5678-9012/1",
             commands=[cmd],
@@ -824,11 +890,11 @@ class TestImmutability:
             await client_rts_0.execute_action_group([action])
 
             called_actions = mock_exec.call_args[0][0]
-            assert called_actions[0].commands[0].parameters == [0]
+            assert called_actions[0].commands[0].parameters == [50, 0]
 
-        # Original list must still be empty
-        assert original_params == []
-        assert cmd.parameters == []
+        # Original list must still be [50]
+        assert original_params == [50]
+        assert cmd.parameters == [50]
 
 
 # ---------------------------------------------------------------------------
@@ -836,25 +902,21 @@ class TestImmutability:
 # ---------------------------------------------------------------------------
 
 
-class TestEquivalenceWithOldApproach:
-    """Verify the nparams=1 rule produces correct results for real RTS devices.
+class TestRealDeviceScenarios:
+    """Tests based on real Overkiz API documentation and fixture data.
 
-    Based on actual Overkiz API fixture data (cloud_somfy_connexoon_rts_asia.json):
-    - Movement commands (close, open, up, down, stop, my, rest): nparams=1 -> GET duration
-    - Utility commands (identify, test): nparams=0 -> no injection
-    - Tilt/move commands (tiltPositive, tiltNegative, moveOf): nparams=2 -> no injection
-    - Some venetian blind devices have open/close/stop at nparams=0 -> no injection
-
-    The old COMMANDS_WITHOUT_DELAY blocklist (identify, off, on, onWithTimer,
-    test, tiltPositive, tiltNegative) is no longer needed because:
-    - identify, test: nparams=0 — naturally excluded
-    - tiltPositive, tiltNegative: nparams=2 — excluded by nparams==1 rule
-    - off, on, onWithTimer: don't exist on real RTS devices in the fixtures
+    Per the API docs, the last parameter of every RTS command that accepts
+    parameters is the execution duration:
+    - close/open/up/down/stop/my/rest (nparams=1): p1=duration (default 30)
+    - tiltPositive/tiltNegative (nparams=2): p1=position, p2=duration (default 15)
+    - moveOf (nparams=2): p1=position, p2=duration
+    - identify/test (nparams=0): no parameters, no duration
+    - Some venetian blind devices define open/close/stop with nparams=0
     """
 
     @pytest.mark.asyncio
-    async def test_movement_commands_injected(self, client_rts_0):
-        """All movement commands with nparams=1 get duration injected."""
+    async def test_movement_commands_no_args(self, client_rts_0):
+        """Movement commands called without args get duration injected."""
         client_rts_0.devices = [_rts_device()]
 
         for cmd_name in ("close", "open", "up", "down", "stop", "my", "rest"):
@@ -871,12 +933,38 @@ class TestEquivalenceWithOldApproach:
 
                 called_actions = mock_exec.call_args[0][0]
                 assert called_actions[0].commands[0].parameters == [0], (
-                    f"'{cmd_name}' (nparams=1) must get duration=0"
+                    f"'{cmd_name}' (nparams=1, no args) must get duration=0"
                 )
 
     @pytest.mark.asyncio
-    async def test_tilt_commands_not_injected(self, client_rts_0):
-        """tiltPositive/tiltNegative have nparams=2 (position, speed) — not duration."""
+    async def test_tilt_commands_with_position_get_duration(self, client_rts_0):
+        """Tilt commands called with position get duration as last param."""
+        client_rts_0.devices = [_rts_device()]
+
+        for cmd_name, position in [
+            ("tiltPositive", [1]),
+            ("tiltNegative", [15]),
+            ("moveOf", [50]),
+        ]:
+            action = Action(
+                device_url="rts://1234-5678-9012/1",
+                commands=[Command(name=cmd_name, parameters=position)],
+            )
+
+            with patch.object(
+                client_rts_0, "_execute_action_group_direct", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_exec.return_value = "exec-123"
+                await client_rts_0.execute_action_group([action])
+
+                called_actions = mock_exec.call_args[0][0]
+                assert called_actions[0].commands[0].parameters == [*position, 0], (
+                    f"'{cmd_name}' with position should get duration appended"
+                )
+
+    @pytest.mark.asyncio
+    async def test_tilt_commands_without_position_not_injected(self, client_rts_0):
+        """Tilt commands called without position: duration not injected (position missing)."""
         client_rts_0.devices = [_rts_device()]
 
         for cmd_name in ("tiltPositive", "tiltNegative", "moveOf"):
@@ -893,7 +981,7 @@ class TestEquivalenceWithOldApproach:
 
                 called_actions = mock_exec.call_args[0][0]
                 assert called_actions[0].commands[0].parameters is None, (
-                    f"'{cmd_name}' (nparams=2) must NOT get duration"
+                    f"'{cmd_name}' without position must NOT get duration"
                 )
 
     @pytest.mark.asyncio
@@ -912,17 +1000,18 @@ class TestEquivalenceWithOldApproach:
         )
         client_rts_0.devices = [device]
 
-        for cmd_name, expect_injection in [
-            ("open", False),
-            ("close", False),
-            ("stop", False),
-            ("my", True),
-            ("tiltPositive", False),
-            ("identify", False),
+        for cmd_name, params, expected in [
+            ("open", None, None),  # nparams=0: no injection
+            ("close", None, None),  # nparams=0: no injection
+            ("stop", None, None),  # nparams=0: no injection
+            ("my", None, [0]),  # nparams=1, 0 params: inject
+            ("tiltPositive", None, None),  # nparams=2, 0 params: no injection
+            ("tiltPositive", [50], [50, 0]),  # nparams=2, 1 param: inject
+            ("identify", None, None),  # nparams=0: no injection
         ]:
             action = Action(
                 device_url="rts://1234-5678-9012/1",
-                commands=[Command(name=cmd_name)],
+                commands=[Command(name=cmd_name, parameters=params)],
             )
 
             with patch.object(
@@ -932,11 +1021,10 @@ class TestEquivalenceWithOldApproach:
                 await client_rts_0.execute_action_group([action])
 
                 called_actions = mock_exec.call_args[0][0]
-                params = called_actions[0].commands[0].parameters
-                if expect_injection:
-                    assert params == [0], f"'{cmd_name}' should get duration"
-                else:
-                    assert params is None, f"'{cmd_name}' should NOT get duration"
+                actual = called_actions[0].commands[0].parameters
+                assert actual == expected, (
+                    f"'{cmd_name}' with params={params}: expected {expected}, got {actual}"
+                )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Fixes the RTS duration injection logic** to correctly handle multi-param commands like `tiltPositive` and `moveOf` based on the Overkiz API documentation
- **Renames `rts_command_duration` to `default_rts_command_duration`** to make clear it's a default that users can override by passing the duration themselves
- **Adds 50 tests** covering all RTS injection scenarios

## Problem

The original implementation used `current_count < nparams` which would incorrectly inject duration into domain-specific parameter slots. For example, `tiltPositive(nparams=2)` called with only 1 param would get duration injected as the position value.

## Fix

Per the Overkiz API docs, the **last parameter of every RTS command is always the execution duration**. The correct injection rule is `current_count == nparams - 1` — only inject when all domain-specific params are filled and exactly the duration slot remains empty.

| Command | nparams | Last param | Injection behavior |
|---------|---------|------------|--------------------|
| `close`, `open`, `up`, `down`, `stop`, `my`, `rest` | 1 | duration (default 30s) | Injected when called with no args |
| `tiltPositive`, `tiltNegative`, `moveOf` | 2 | duration (default 15s) | Injected when called with position arg only |
| `identify`, `test` | 0 | — | Never injected |

If a user explicitly provides the duration parameter, their value is never overwritten.

## Test plan

- [x] All 50 RTS injection tests pass
- [x] Full test suite (480 tests) passes
- [x] mypy and ty type checking pass
- [ ] Verify HA integration works with renamed `default_rts_command_duration` setting