### PR TITLE
Make Gateway.connectivity non-optional

### DIFF
--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -658,7 +658,7 @@ class Gateway:
     """Representation of a gateway, including connectivity and partner info."""
 
     gateway_id: str = field(repr=obfuscate_id)
-    connectivity: Connectivity | None = None
+    connectivity: Connectivity
     partners: list[Partner] = field(factory=list)
     functions: str | None = None
     sub_type: GatewaySubType | None = None


### PR DESCRIPTION
## Summary
- Remove `| None = None` from `Gateway.connectivity` field since the API always returns a connectivity object
- Verified across all 35+ gateway instances in test fixtures — none have a missing connectivity field

## Test plan
- [x] All 456 existing tests pass
- [x] mypy reports no issues