### PR TITLE
Use PAT for generate-enums so it can push workflow changes

### DIFF
--- a/.github/workflows/generate-enums.yml
+++ b/.github/workflows/generate-enums.yml
@@ -16,6 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          # PAT with workflows scope so the push can touch .github/workflows/*
+          # and so the opened PR triggers CI (GITHUB_TOKEN cannot do either).
+          token: ${{ secrets.GENERATE_ENUMS_TOKEN }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -45,6 +49,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.GENERATE_ENUMS_TOKEN }}
           commit-message: "Update generated enums and docs from Overkiz API"
           title: "Update generated enums and docs from Overkiz API"
           body: |


### PR DESCRIPTION
## Problem

The weekly `generate-enums` workflow failed at the **Create pull request** step. All the real work (fetch server data, generate enums, generate device catalog docs) succeeded — only the push was rejected:

```
! [remote rejected] automated/generate-enums -> automated/generate-enums
  (refusing to allow a GitHub App to create or update workflow `.github/workflows/docs.yml`
   without `workflows` permission)
```

The default `GITHUB_TOKEN` is categorically forbidden from pushing changes under `.github/workflows/` — this can't be granted via the `permissions:` block. `docs.yml` drifted into the diff because the stale `automated/generate-enums` branch was based on an older `main`.

## Fix

Use a fine-grained PAT (`GENERATE_ENUMS_TOKEN`, stored in the `overkiz-api` environment with Contents / Pull requests / Workflows write) for both the `checkout` and `create-pull-request` steps. As a bonus, PRs opened with a PAT trigger CI (those opened with `GITHUB_TOKEN` don't).

Manual dispatch (`workflow_dispatch`) was already enabled.

## Follow-up (not in this PR)

`peter-evans/create-pull-request@v7` runs on Node 20, which GitHub force-migrates to Node 24 on 2026-06-02 — worth bumping soon.