### PR TITLE
Document that ExecutionMode is Cloud API only

### DIFF
--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -48,6 +48,8 @@ An optional `ExecutionMode` can be passed when executing an action group:
 - `GEOLOCATED` — Triggered by geolocation rules.
 - `INTERNAL` — Used for internal/system executions.
 
+Execution modes are only supported by the **Cloud API**. The local API (Somfy TaHoma Developer Mode) does not accept an execution mode and will reject the request. See [Somfy-TaHoma-Developer-Mode#227](https://github.com/Somfy-Developer/Somfy-TaHoma-Developer-Mode/issues/227).
+
 ## UI profiles and classifiers
 
 Each device definition includes **UI profiles** and **UI classifiers** that describe what the device can do at a higher level than raw commands.

--- a/docs/device-control.md
+++ b/docs/device-control.md
@@ -254,6 +254,12 @@ exec_id = await client.execute_action_group(
 
 Available modes: `HIGH_PRIORITY`, `GEOLOCATED`, `INTERNAL`. When omitted, the default execution mode is used.
 
+!!! warning
+    Execution modes are only supported by the **Cloud API**. The local API
+    (Somfy TaHoma Developer Mode) does not accept an execution mode and will
+    reject the request. See
+    [Somfy-TaHoma-Developer-Mode#227](https://github.com/Somfy-Developer/Somfy-TaHoma-Developer-Mode/issues/227).
+
 ## Track and cancel executions
 
 ```python

--- a/docs/migration-v2.md
+++ b/docs/migration-v2.md
@@ -110,7 +110,7 @@ The command execution API has been consolidated into a single method.
     )
     ```
 
-v2 also supports sending actions to **multiple devices** in a single call and choosing an `ExecutionMode` (`HIGH_PRIORITY`, `GEOLOCATED`, `INTERNAL`).
+v2 also supports sending actions to **multiple devices** in a single call and choosing an `ExecutionMode` (`HIGH_PRIORITY`, `GEOLOCATED`, `INTERNAL`). Execution modes are only supported by the Cloud API; the local API rejects them (see [Somfy-TaHoma-Developer-Mode#227](https://github.com/Somfy-Developer/Somfy-TaHoma-Developer-Mode/issues/227)).
 
 ## Diagnostics
 

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -611,7 +611,7 @@ class OverkizClient:
             mode: Optional execution mode (``HIGH_PRIORITY``, ``GEOLOCATED``,
                 or ``INTERNAL``). Only supported by the Cloud API; the local
                 API rejects requests that specify an execution mode (see
-                Somfy-TaHoma-Developer-Mode issue #227).
+                https://github.com/Somfy-Developer/Somfy-TaHoma-Developer-Mode/issues/227).
             label: Human-readable label for the execution.
 
         Returns:

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -609,7 +609,9 @@ class OverkizClient:
             actions: One or more actions to execute. Each action targets a
                 single device and holds one or more commands.
             mode: Optional execution mode (``HIGH_PRIORITY``, ``GEOLOCATED``,
-                or ``INTERNAL``).
+                or ``INTERNAL``). Only supported by the Cloud API; the local
+                API rejects requests that specify an execution mode (see
+                Somfy-TaHoma-Developer-Mode issue #227).
             label: Human-readable label for the execution.
 
         Returns:


### PR DESCRIPTION
## Summary

Documents that `ExecutionMode` is only supported by the **Cloud API**. The local API (Somfy TaHoma Developer Mode) does not accept an execution mode and rejects the request.

Added a note in three docs pages and the `execute_action_group` docstring, each linking the upstream issue.

## Changes

- `docs/device-control.md` — warning admonition under the execution-modes example
- `docs/core-concepts.md` — note under the execution-modes list
- `docs/migration-v2.md` — appended caveat to the existing `ExecutionMode` mention
- `pyoverkiz/client.py` — `execute_action_group` docstring `mode` arg

## Reference

See https://github.com/Somfy-Developer/Somfy-TaHoma-Developer-Mode/issues/227