### PR TITLE
feat(auth): Rexel authentication (OAuth2 PKCE + externally-managed tokens)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,3 @@ dmypy.json
 
 # File-based project format
 *.iws
-
-# Throwaway manual exploration script for the Rexel OAuth2 + proxy flow
-rexel_flow_test.py

--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ dmypy.json
 
 # File-based project format
 *.iws
+
+# Throwaway manual exploration script for the Rexel OAuth2 + proxy flow
+rexel_flow_test.py

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -88,6 +88,20 @@ The library supports multiple authentication methods depending on the server:
 
 Each server automatically selects the appropriate authentication strategy based on the credentials provided.
 
+Rexel supports two authentication modes:
+
+- **Library-driven code exchange** (`RexelOAuthCodeCredentials`): pyoverkiz
+  performs the PKCE code exchange and refreshes its own tokens. Best for
+  standalone use.
+- **Externally-managed token** (`RexelTokenCredentials`): the OAuth2 lifecycle
+  is owned outside the library (e.g. Home Assistant's `application_credentials`
+  platform). Supply an async `access_token_callback` or a static `access_token`.
+  Best when a host application already manages OAuth.
+
+Both Rexel modes support multiple gateways: after `login()`, call
+`discover_gateways()` and `select_gateway()` to scope requests (a sole gateway
+is auto-selected).
+
 ## Relationship diagram
 
 ```

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -77,6 +77,17 @@ States are name/value pairs that represent the current device status, such as cl
 
 The API uses an event listener that you register once per session. Fetching events drains the server-side buffer. Events include execution state changes, device state updates, and other notifications.
 
+## Authentication strategies
+
+The library supports multiple authentication methods depending on the server:
+
+- **Username/Password**: Most cloud servers (Somfy, Cozytouch, Hitachi, Nexity)
+- **Bearer Token**: Cloud servers with pre-issued tokens
+- **Local Token**: Somfy Developer Mode (local gateways)
+- **OAuth2 with PKCE**: Rexel (Azure AD B2C)
+
+Each server automatically selects the appropriate authentication strategy based on the credentials provided.
+
 ## Relationship diagram
 
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -202,3 +202,63 @@ Use a cloud server when you want to connect through the vendor’s public API. U
 
     asyncio.run(main())
     ```
+
+=== "Rexel (externally-managed token)"
+
+    Use this when an external system already owns the OAuth2 lifecycle — for
+    example the Home Assistant `application_credentials` platform, which
+    authorizes, exchanges, refreshes, and persists tokens for you. pyoverkiz
+    then only needs the *current* access token and the Rexel gateway selection.
+
+    Supply a token in one of two ways:
+
+    **Async callback (recommended for long-running apps).** pyoverkiz calls it
+    before each request, so the owner can refresh and persist transparently.
+
+    ```python
+    import asyncio
+    from pyoverkiz.auth.credentials import RexelTokenCredentials
+    from pyoverkiz.client import OverkizClient
+    from pyoverkiz.enums import Server
+
+
+    async def get_access_token() -> str:
+        # Return a currently-valid access token (refresh upstream as needed).
+        ...
+
+
+    async def main() -> None:
+        async with OverkizClient(
+            server=Server.REXEL,
+            credentials=RexelTokenCredentials(
+                access_token_callback=get_access_token,
+            ),
+        ) as client:
+            await client.login()  # discovers + auto-selects a sole gateway
+
+            gateways = await client.discover_gateways()
+            if len(gateways) > 1:
+                client.select_gateway(gateways[0].gateway_id)
+
+            setup = await client.get_setup()
+            print(f"{len(setup.devices)} device(s)")
+
+    asyncio.run(main())
+    ```
+
+    **Static token (simplest, for quick standalone or test use).** No refresh —
+    when the token expires you construct a new client.
+
+    ```python
+    credentials = RexelTokenCredentials(access_token="YOUR_ACCESS_TOKEN")
+    ```
+
+    **Reload without re-discovering.** Persist the chosen `gateway_id` and pass
+    it back on the next run; `login()` applies it directly and skips discovery:
+
+    ```python
+    credentials = RexelTokenCredentials(
+        access_token_callback=get_access_token,
+        gateway_id="STORED_GATEWAY_ID",
+    )
+    ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -150,31 +150,55 @@ Use a cloud server when you want to connect through the vendor’s public API. U
     asyncio.run(main())
     ```
 
-<!-- TODO: Rexel OAuth2 flow not fully working yet
 === "Rexel (cloud)"
 
-    Authentication to the Rexel cloud uses OAuth2 authorization code flow.
-    You need an authorization code and redirect URI obtained from the Rexel OAuth2 consent flow.
+    Authentication to the Rexel cloud uses OAuth2 with PKCE (Proof Key for Code Exchange).
 
-    Use `Server.REXEL` with `RexelOAuthCodeCredentials` to authenticate.
+    **Step 1: Generate PKCE parameters and authorization URL**
+
+    ```python
+    import secrets
+    from pyoverkiz.pkce import generate_pkce_pair
+    from pyoverkiz.utils import build_rexel_authorization_url
+
+    # Generate PKCE code verifier and challenge
+    code_verifier, code_challenge = generate_pkce_pair()
+
+    # Generate authorization URL (user must visit this in browser)
+    state = secrets.token_urlsafe(16)  # For CSRF protection
+    auth_url = build_rexel_authorization_url(code_challenge, state)
+
+    print(f"Visit this URL to authorize: {auth_url}")
+    ```
+
+    **Step 2: Redirect user to authorization URL**
+
+    Direct the user to the `auth_url`. After successful login, they will be redirected to:
+    ```
+    https://my.home-assistant.io/redirect/oauth?code=AUTHORIZATION_CODE&state=STATE_VALUE
+    ```
+
+    **Step 3: Exchange authorization code for access token**
 
     ```python
     import asyncio
-
     from pyoverkiz.auth.credentials import RexelOAuthCodeCredentials
     from pyoverkiz.client import OverkizClient
     from pyoverkiz.enums import Server
+    from pyoverkiz.const import REXEL_OAUTH_REDIRECT_URI
 
     async def main() -> None:
+        # Use the authorization code from the redirect
         async with OverkizClient(
             server=Server.REXEL,
             credentials=RexelOAuthCodeCredentials(
-                code="your-authorization-code",
-                redirect_uri="https://your-redirect-uri",
+                code="AUTHORIZATION_CODE_FROM_REDIRECT",
+                redirect_uri=REXEL_OAUTH_REDIRECT_URI,
+                code_verifier=code_verifier,  # From step 1
             ),
         ) as client:
             await client.login()
+            # Client is now authenticated and ready to use
 
     asyncio.run(main())
     ```
--->

--- a/docs/migration-v2.md
+++ b/docs/migration-v2.md
@@ -411,3 +411,26 @@ These are not breaking, but worth knowing about when migrating:
 - **Reference endpoints** — query server metadata: `get_reference_ui_classes()`, `get_reference_ui_widgets()`, `get_reference_ui_profile()`, `get_reference_controllable_types()`, etc.
 - **Firmware management** — `get_devices_not_up_to_date()`, `get_device_firmware_status()`, `update_device_firmware()`.
 - **Optional Nexity dependencies** — `boto3` and `warrant-lite` are no longer installed by default. Install them with `pip install "pyoverkiz[nexity]"` if you use the Nexity server. A clear `ImportError` is raised at login time if the extra is missing.
+
+## `auth_headers` is now async
+
+`AuthStrategy.auth_headers()` and every concrete strategy's implementation are
+now coroutines. This only affects code that calls `auth_headers()` directly or
+implements a custom `AuthStrategy` — normal `OverkizClient` use is unaffected.
+
+=== "Before"
+
+    ```python
+    headers = strategy.auth_headers(path)
+    ```
+
+=== "After"
+
+    ```python
+    headers = await strategy.auth_headers(path)
+    ```
+
+Custom strategies must change the method signature to `async def auth_headers`.
+This change lets token-supplied strategies (such as Rexel's
+`RexelTokenAuthStrategy`) await an externally-supplied access-token callback per
+request instead of caching token state.

--- a/docs/sdk-reference.md
+++ b/docs/sdk-reference.md
@@ -11,3 +11,14 @@
 ::: pyoverkiz.exceptions
     options:
       show_source: false
+
+::: pyoverkiz.auth.credentials
+    options:
+      show_source: false
+
+::: pyoverkiz.auth.base
+    options:
+      show_source: false
+      members:
+        - GatewayCandidate
+        - SupportsGatewaySelection

--- a/pyoverkiz/auth/__init__.py
+++ b/pyoverkiz/auth/__init__.py
@@ -12,6 +12,7 @@ from pyoverkiz.auth.credentials import (
     Credentials,
     LocalTokenCredentials,
     RexelOAuthCodeCredentials,
+    RexelTokenCredentials,
     TokenCredentials,
     UsernamePasswordCredentials,
 )
@@ -24,6 +25,7 @@ __all__ = [
     "GatewayCandidate",
     "LocalTokenCredentials",
     "RexelOAuthCodeCredentials",
+    "RexelTokenCredentials",
     "SupportsGatewaySelection",
     "TokenCredentials",
     "UsernamePasswordCredentials",

--- a/pyoverkiz/auth/__init__.py
+++ b/pyoverkiz/auth/__init__.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from pyoverkiz.auth.base import AuthContext, AuthStrategy
+from pyoverkiz.auth.base import (
+    AuthContext,
+    AuthStrategy,
+    GatewayCandidate,
+    SupportsGatewaySelection,
+)
 from pyoverkiz.auth.credentials import (
     Credentials,
     LocalTokenCredentials,
@@ -16,8 +21,10 @@ __all__ = [
     "AuthContext",
     "AuthStrategy",
     "Credentials",
+    "GatewayCandidate",
     "LocalTokenCredentials",
     "RexelOAuthCodeCredentials",
+    "SupportsGatewaySelection",
     "TokenCredentials",
     "UsernamePasswordCredentials",
     "build_auth_strategy",

--- a/pyoverkiz/auth/base.py
+++ b/pyoverkiz/auth/base.py
@@ -65,6 +65,7 @@ class GatewayCandidate:
     gateway_id: str
     home_id: str | None = None
     label: str | None = None
+    external_id: str | None = None
 
 
 @runtime_checkable

--- a/pyoverkiz/auth/base.py
+++ b/pyoverkiz/auth/base.py
@@ -47,7 +47,7 @@ class AuthStrategy(Protocol):
     async def refresh_if_needed(self) -> bool:
         """Refresh tokens if they are expired. Return True if refreshed."""
 
-    def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
+    async def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
         """Generate authentication headers for requests."""
 
     @property

--- a/pyoverkiz/auth/base.py
+++ b/pyoverkiz/auth/base.py
@@ -50,5 +50,9 @@ class AuthStrategy(Protocol):
     def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
         """Generate authentication headers for requests."""
 
+    @property
+    def endpoint(self) -> str:
+        """Return the base API endpoint for requests."""
+
     async def close(self) -> None:
         """Clean up any resources held by the strategy."""

--- a/pyoverkiz/auth/base.py
+++ b/pyoverkiz/auth/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import Any, Protocol, runtime_checkable
 
 
 @dataclass(slots=True)
@@ -56,3 +56,27 @@ class AuthStrategy(Protocol):
 
     async def close(self) -> None:
         """Clean up any resources held by the strategy."""
+
+
+@dataclass(slots=True)
+class GatewayCandidate:
+    """A selectable Overkiz gateway behind a multi-account directory."""
+
+    gateway_id: str
+    home_id: str | None = None
+    label: str | None = None
+
+
+@runtime_checkable
+class SupportsGatewaySelection(Protocol):
+    """Optional capability: discover and select among multiple gateways."""
+
+    async def discover_gateways(self) -> list[GatewayCandidate]:
+        """Return all selectable gateways for the authenticated account."""
+
+    def select_gateway(self, gateway_id: str) -> None:
+        """Select the gateway to scope subsequent requests to."""
+
+    @property
+    def selected_gateway(self) -> str | None:
+        """Return the currently selected gateway id, or None."""

--- a/pyoverkiz/auth/credentials.py
+++ b/pyoverkiz/auth/credentials.py
@@ -32,7 +32,8 @@ class LocalTokenCredentials(TokenCredentials):
 
 @dataclass(slots=True)
 class RexelOAuthCodeCredentials(Credentials):
-    """Credentials using Rexel OAuth2 authorization code."""
+    """Credentials using Rexel OAuth2 authorization code with PKCE."""
 
     code: str = field(repr=False)
     redirect_uri: str
+    code_verifier: str

--- a/pyoverkiz/auth/credentials.py
+++ b/pyoverkiz/auth/credentials.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 
 
@@ -37,3 +38,25 @@ class RexelOAuthCodeCredentials(Credentials):
     code: str = field(repr=False)
     redirect_uri: str
     code_verifier: str
+
+
+@dataclass(slots=True)
+class RexelTokenCredentials(Credentials):
+    """Rexel credentials backed by an externally-managed access token.
+
+    Use this when the OAuth2 lifecycle is owned outside pyoverkiz (for example
+    Home Assistant's ``application_credentials`` platform). Supply either an
+    async ``access_token_callback`` (called before each request, so the owner
+    can refresh and persist tokens) or a static ``access_token`` for simple
+    standalone or test use. ``gateway_id`` pre-selects a gateway on reload,
+    skipping discovery.
+    """
+
+    access_token_callback: Callable[[], Awaitable[str]] | None = None
+    access_token: str | None = field(default=None, repr=False)
+    gateway_id: str | None = None
+
+    def __post_init__(self) -> None:
+        """Require at least one access-token source."""
+        if not self.access_token_callback and not self.access_token:
+            raise ValueError("Provide either access_token_callback or access_token.")

--- a/pyoverkiz/auth/factory.py
+++ b/pyoverkiz/auth/factory.py
@@ -10,6 +10,7 @@ from pyoverkiz.auth.credentials import (
     Credentials,
     LocalTokenCredentials,
     RexelOAuthCodeCredentials,
+    RexelTokenCredentials,
     TokenCredentials,
     UsernamePasswordCredentials,
 )
@@ -20,6 +21,7 @@ from pyoverkiz.auth.strategies import (
     LocalTokenAuthStrategy,
     NexityAuthStrategy,
     RexelAuthStrategy,
+    RexelTokenAuthStrategy,
     SessionLoginStrategy,
     SomfyAuthStrategy,
 )
@@ -66,6 +68,10 @@ def build_auth_strategy(
         )
 
     if server == Server.REXEL:
+        if isinstance(credentials, RexelTokenCredentials):
+            return RexelTokenAuthStrategy(
+                credentials, session, server_config, ssl_context
+            )
         return RexelAuthStrategy(
             _ensure_credentials(credentials, RexelOAuthCodeCredentials),
             session,

--- a/pyoverkiz/auth/strategies.py
+++ b/pyoverkiz/auth/strategies.py
@@ -67,6 +67,11 @@ class BaseAuthStrategy(AuthStrategy):
         self.server = server
         self._ssl = ssl_context
 
+    @property
+    def endpoint(self) -> str:
+        """Return the base API endpoint; defaults to the server endpoint."""
+        return self.server.endpoint
+
     async def login(self) -> None:
         """Perform authentication; default is a no-op for subclasses to override."""
         return

--- a/pyoverkiz/auth/strategies.py
+++ b/pyoverkiz/auth/strategies.py
@@ -31,6 +31,7 @@ from pyoverkiz.const import (
     NEXITY_COGNITO_REGION,
     NEXITY_COGNITO_USER_POOL,
     REXEL_ENDUSER_API,
+    REXEL_GATEWAY_HEADER,
     REXEL_OAUTH_CLIENT_ID,
     REXEL_OAUTH_SCOPE,
     REXEL_OAUTH_TOKEN_URL,
@@ -46,6 +47,7 @@ from pyoverkiz.exceptions import (
     InvalidTokenError,
     NexityBadCredentialsError,
     NexityServiceError,
+    NoGatewaySelectedError,
     SomfyBadCredentialsError,
     SomfyServiceError,
 )
@@ -415,10 +417,18 @@ class RexelAuthStrategy(BaseAuthStrategy):
             return cast(list[dict[str, Any]], await response.json())
 
     def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
-        """Return authentication headers for a request path."""
-        if self.context.access_token:
-            return {"Authorization": f"Bearer {self.context.access_token}"}
-        return {}
+        """Return authentication headers, including the selected gateway."""
+        if not self.context.access_token:
+            return {}
+        if self._gateway_id is None:
+            raise NoGatewaySelectedError(
+                "Multiple Rexel gateways available; call discover_gateways() "
+                "and select_gateway() before making requests."
+            )
+        return {
+            "Authorization": f"Bearer {self.context.access_token}",
+            REXEL_GATEWAY_HEADER: self._gateway_id,
+        }
 
     async def _exchange_token(self, payload: Mapping[str, str]) -> None:
         """Exchange authorization code or refresh token for access token."""

--- a/pyoverkiz/auth/strategies.py
+++ b/pyoverkiz/auth/strategies.py
@@ -344,6 +344,7 @@ class RexelAuthStrategy(BaseAuthStrategy):
                 "scope": REXEL_OAUTH_SCOPE,
                 "code": self.credentials.code,
                 "redirect_uri": self.credentials.redirect_uri,
+                "code_verifier": self.credentials.code_verifier,
             }
         )
 
@@ -370,11 +371,9 @@ class RexelAuthStrategy(BaseAuthStrategy):
 
     async def _exchange_token(self, payload: Mapping[str, str]) -> None:
         """Exchange authorization code or refresh token for access token."""
-        form = FormData(payload)
         async with self.session.post(
             REXEL_OAUTH_TOKEN_URL,
-            data=form,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data=payload,
         ) as response:
             token = await response.json()
 

--- a/pyoverkiz/auth/strategies.py
+++ b/pyoverkiz/auth/strategies.py
@@ -84,7 +84,7 @@ class BaseAuthStrategy(AuthStrategy):
         """Refresh authentication tokens if needed; default returns False."""
         return False
 
-    def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
+    async def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
         """Return authentication headers for a request path."""
         return {}
 
@@ -172,7 +172,7 @@ class SomfyAuthStrategy(BaseAuthStrategy):
         )
         return True
 
-    def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
+    async def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
         """Return authentication headers for a request path."""
         if self.context.access_token:
             return {"Authorization": f"Bearer {self.context.access_token}"}
@@ -324,7 +324,7 @@ class LocalTokenAuthStrategy(BaseAuthStrategy):
         if not self.credentials.token:
             raise InvalidTokenError("Local API requires a token.")
 
-    def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
+    async def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
         """Return authentication headers for a request path."""
         return {"Authorization": f"Bearer {self.credentials.token}"}
 
@@ -424,7 +424,7 @@ class RexelAuthStrategy(BaseAuthStrategy):
             await check_response(response)
             return cast(list[dict[str, Any]], await response.json())
 
-    def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
+    async def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
         """Return authentication headers, including the selected gateway."""
         if not self.context.access_token:
             return {}
@@ -486,7 +486,7 @@ class BearerTokenAuthStrategy(BaseAuthStrategy):
         super().__init__(session, server, ssl_context)
         self.credentials = credentials
 
-    def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
+    async def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
         """Return authentication headers for a request path."""
         if self.credentials.token:
             return {"Authorization": f"Bearer {self.credentials.token}"}

--- a/pyoverkiz/auth/strategies.py
+++ b/pyoverkiz/auth/strategies.py
@@ -329,52 +329,20 @@ class LocalTokenAuthStrategy(BaseAuthStrategy):
         return {"Authorization": f"Bearer {self.credentials.token}"}
 
 
-class RexelAuthStrategy(BaseAuthStrategy):
-    """Authentication strategy using Rexel OAuth2."""
+class RexelGatewayMixin:
+    """Shared Rexel gateway discovery/selection for Rexel auth strategies.
 
-    def __init__(
-        self,
-        credentials: RexelOAuthCodeCredentials,
-        session: ClientSession,
-        server: ServerConfig,
-        ssl_context: ssl.SSLContext | bool,
-    ) -> None:
-        """Create a Rexel OAuth2 strategy with a fresh auth context."""
-        super().__init__(session, server, ssl_context)
-        self.credentials = credentials
-        self.context = AuthContext()
-        self._gateway_id: str | None = None
+    The only per-strategy difference is how the access token is obtained,
+    supplied by overriding ``_current_access_token``.
+    """
 
-    async def login(self) -> None:
-        """Exchange the authorization code, then auto-select a sole gateway."""
-        await self._exchange_token(
-            {
-                "grant_type": "authorization_code",
-                "client_id": REXEL_OAUTH_CLIENT_ID,
-                "scope": REXEL_OAUTH_SCOPE,
-                "code": self.credentials.code,
-                "redirect_uri": self.credentials.redirect_uri,
-                "code_verifier": self.credentials.code_verifier,
-            }
-        )
-        gateways = await self.discover_gateways()
-        if len(gateways) == 1:
-            self.select_gateway(gateways[0].gateway_id)
+    session: ClientSession
+    _ssl: ssl.SSLContext | bool
+    _gateway_id: str | None
 
-    async def refresh_if_needed(self) -> bool:
-        """Refresh Rexel OAuth2 tokens if needed."""
-        if not self.context.is_expired() or not self.context.refresh_token:
-            return False
-
-        await self._exchange_token(
-            {
-                "grant_type": "refresh_token",
-                "client_id": REXEL_OAUTH_CLIENT_ID,
-                "scope": REXEL_OAUTH_SCOPE,
-                "refresh_token": cast(str, self.context.refresh_token),
-            }
-        )
-        return True
+    async def _current_access_token(self) -> str | None:
+        """Return the current access token. Overridden per strategy."""
+        raise NotImplementedError
 
     async def discover_gateways(self) -> list[GatewayCandidate]:
         """Enumerate every home x gateway available to this account."""
@@ -418,25 +386,79 @@ class RexelAuthStrategy(BaseAuthStrategy):
         """
         async with self.session.get(
             f"{REXEL_ENDUSER_API}/{path}",
-            headers={"Authorization": f"Bearer {self.context.access_token}"},
+            headers={"Authorization": f"Bearer {await self._current_access_token()}"},
             ssl=self._ssl,
         ) as response:
             await check_response(response)
             return cast(list[dict[str, Any]], await response.json())
 
-    async def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
-        """Return authentication headers, including the selected gateway."""
-        if not self.context.access_token:
-            return {}
+    def _gateway_headers(self) -> dict[str, str]:
+        """Return the gatewayId header; raise if no gateway is selected."""
         if self._gateway_id is None:
             raise NoGatewaySelectedError(
                 "Multiple Rexel gateways available; call discover_gateways() "
                 "and select_gateway() before making requests."
             )
-        return {
-            "Authorization": f"Bearer {self.context.access_token}",
-            REXEL_GATEWAY_HEADER: self._gateway_id,
-        }
+        return {REXEL_GATEWAY_HEADER: self._gateway_id}
+
+    async def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
+        """Return Bearer + gatewayId headers, or {} before a token exists."""
+        token = await self._current_access_token()
+        if not token:
+            return {}
+        return {"Authorization": f"Bearer {token}", **self._gateway_headers()}
+
+
+class RexelAuthStrategy(RexelGatewayMixin, BaseAuthStrategy):
+    """Authentication strategy using Rexel OAuth2 code exchange."""
+
+    def __init__(
+        self,
+        credentials: RexelOAuthCodeCredentials,
+        session: ClientSession,
+        server: ServerConfig,
+        ssl_context: ssl.SSLContext | bool,
+    ) -> None:
+        """Create a Rexel OAuth2 strategy with a fresh auth context."""
+        super().__init__(session, server, ssl_context)
+        self.credentials = credentials
+        self.context = AuthContext()
+        self._gateway_id: str | None = None
+
+    async def _current_access_token(self) -> str | None:
+        """Return the access token from the OAuth2 code-exchange context."""
+        return self.context.access_token
+
+    async def login(self) -> None:
+        """Exchange the authorization code, then auto-select a sole gateway."""
+        await self._exchange_token(
+            {
+                "grant_type": "authorization_code",
+                "client_id": REXEL_OAUTH_CLIENT_ID,
+                "scope": REXEL_OAUTH_SCOPE,
+                "code": self.credentials.code,
+                "redirect_uri": self.credentials.redirect_uri,
+                "code_verifier": self.credentials.code_verifier,
+            }
+        )
+        gateways = await self.discover_gateways()
+        if len(gateways) == 1:
+            self.select_gateway(gateways[0].gateway_id)
+
+    async def refresh_if_needed(self) -> bool:
+        """Refresh Rexel OAuth2 tokens if needed."""
+        if not self.context.is_expired() or not self.context.refresh_token:
+            return False
+
+        await self._exchange_token(
+            {
+                "grant_type": "refresh_token",
+                "client_id": REXEL_OAUTH_CLIENT_ID,
+                "scope": REXEL_OAUTH_SCOPE,
+                "refresh_token": cast(str, self.context.refresh_token),
+            }
+        )
+        return True
 
     async def _exchange_token(self, payload: Mapping[str, str]) -> None:
         """Exchange authorization code or refresh token for access token."""

--- a/pyoverkiz/auth/strategies.py
+++ b/pyoverkiz/auth/strategies.py
@@ -397,7 +397,12 @@ class RexelAuthStrategy(BaseAuthStrategy):
         return candidates
 
     def select_gateway(self, gateway_id: str) -> None:
-        """Select the gateway to scope subsequent requests to."""
+        """Select the gateway to scope subsequent requests to.
+
+        The caller is responsible for passing a ``gateway_id`` obtained from
+        ``discover_gateways()``; an unknown id is only rejected server-side on
+        the next request.
+        """
         self._gateway_id = gateway_id
 
     @property

--- a/pyoverkiz/auth/strategies.py
+++ b/pyoverkiz/auth/strategies.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 from aiohttp import ClientSession, FormData
 
-from pyoverkiz.auth.base import AuthContext, AuthStrategy
+from pyoverkiz.auth.base import AuthContext, AuthStrategy, GatewayCandidate
 from pyoverkiz.auth.credentials import (
     LocalTokenCredentials,
     RexelOAuthCodeCredentials,
@@ -30,6 +30,7 @@ from pyoverkiz.const import (
     NEXITY_COGNITO_CLIENT_ID,
     NEXITY_COGNITO_REGION,
     NEXITY_COGNITO_USER_POOL,
+    REXEL_ENDUSER_API,
     REXEL_OAUTH_CLIENT_ID,
     REXEL_OAUTH_SCOPE,
     REXEL_OAUTH_TOKEN_URL,
@@ -49,6 +50,7 @@ from pyoverkiz.exceptions import (
     SomfyServiceError,
 )
 from pyoverkiz.models import ServerConfig
+from pyoverkiz.response_handler import check_response
 
 MIN_JWT_SEGMENTS = 2
 
@@ -339,6 +341,7 @@ class RexelAuthStrategy(BaseAuthStrategy):
         super().__init__(session, server, ssl_context)
         self.credentials = credentials
         self.context = AuthContext()
+        self._gateway_id: str | None = None
 
     async def login(self) -> None:
         """Perform login using Rexel OAuth2 authorization code."""
@@ -367,6 +370,49 @@ class RexelAuthStrategy(BaseAuthStrategy):
             }
         )
         return True
+
+    async def discover_gateways(self) -> list[GatewayCandidate]:
+        """Enumerate every home x gateway available to this account."""
+        candidates: list[GatewayCandidate] = []
+        for home in await self._get_enduser("homes"):
+            home_id = str(home["id"])
+            home_label = home.get("label")
+            for gateway in await self._get_enduser(f"overkizgateways?homeId={home_id}"):
+                external_id = gateway.get("externalId")
+                candidates.append(
+                    GatewayCandidate(
+                        gateway_id=str(gateway["gatewayId"]),
+                        home_id=home_id,
+                        label=home_label,
+                        external_id=(
+                            str(external_id) if external_id is not None else None
+                        ),
+                    )
+                )
+        return candidates
+
+    def select_gateway(self, gateway_id: str) -> None:
+        """Select the gateway to scope subsequent requests to."""
+        self._gateway_id = gateway_id
+
+    @property
+    def selected_gateway(self) -> str | None:
+        """Return the currently selected gateway id, or None."""
+        return self._gateway_id
+
+    async def _get_enduser(self, path: str) -> list[dict[str, Any]]:
+        """GET a Rexel directory resource (homes/gateways) with Bearer auth.
+
+        Uses REXEL_ENDUSER_API, NOT the device endpoint, and a Bearer-only
+        header so it works before a gateway has been selected.
+        """
+        async with self.session.get(
+            f"{REXEL_ENDUSER_API}/{path}",
+            headers={"Authorization": f"Bearer {self.context.access_token}"},
+            ssl=self._ssl,
+        ) as response:
+            await check_response(response)
+            return cast(list[dict[str, Any]], await response.json())
 
     def auth_headers(self, path: str | None = None) -> Mapping[str, str]:
         """Return authentication headers for a request path."""

--- a/pyoverkiz/auth/strategies.py
+++ b/pyoverkiz/auth/strategies.py
@@ -20,6 +20,7 @@ from pyoverkiz.auth.base import AuthContext, AuthStrategy, GatewayCandidate
 from pyoverkiz.auth.credentials import (
     LocalTokenCredentials,
     RexelOAuthCodeCredentials,
+    RexelTokenCredentials,
     TokenCredentials,
     UsernamePasswordCredentials,
 )
@@ -492,6 +493,42 @@ class RexelAuthStrategy(RexelGatewayMixin, BaseAuthStrategy):
         consent = payload.get("consent")
         if consent != REXEL_REQUIRED_CONSENT:
             raise InvalidTokenError("Consent is missing or revoked for Rexel token.")
+
+
+class RexelTokenAuthStrategy(RexelGatewayMixin, BaseAuthStrategy):
+    """Rexel strategy backed by an externally-managed access token.
+
+    The OAuth2 lifecycle (authorize, exchange, refresh, persistence) is owned
+    by the caller. This strategy only sources the current token and applies the
+    Rexel gateway selection + header logic from RexelGatewayMixin.
+    """
+
+    def __init__(
+        self,
+        credentials: RexelTokenCredentials,
+        session: ClientSession,
+        server: ServerConfig,
+        ssl_context: ssl.SSLContext | bool,
+    ) -> None:
+        """Create a token-backed Rexel strategy bound to the credentials."""
+        super().__init__(session, server, ssl_context)
+        self.credentials = credentials
+        self._gateway_id: str | None = None
+
+    async def login(self) -> None:
+        """Apply a stored gateway, or auto-select a sole discovered gateway."""
+        if self.credentials.gateway_id:
+            self.select_gateway(self.credentials.gateway_id)
+            return
+        gateways = await self.discover_gateways()
+        if len(gateways) == 1:
+            self.select_gateway(gateways[0].gateway_id)
+
+    async def _current_access_token(self) -> str | None:
+        """Return a token from the callback, or the static fallback."""
+        if self.credentials.access_token_callback:
+            return await self.credentials.access_token_callback()
+        return self.credentials.access_token
 
 
 class BearerTokenAuthStrategy(BaseAuthStrategy):

--- a/pyoverkiz/auth/strategies.py
+++ b/pyoverkiz/auth/strategies.py
@@ -346,7 +346,7 @@ class RexelAuthStrategy(BaseAuthStrategy):
         self._gateway_id: str | None = None
 
     async def login(self) -> None:
-        """Perform login using Rexel OAuth2 authorization code."""
+        """Exchange the authorization code, then auto-select a sole gateway."""
         await self._exchange_token(
             {
                 "grant_type": "authorization_code",
@@ -357,6 +357,9 @@ class RexelAuthStrategy(BaseAuthStrategy):
                 "code_verifier": self.credentials.code_verifier,
             }
         )
+        gateways = await self.discover_gateways()
+        if len(gateways) == 1:
+            self.select_gateway(gateways[0].gateway_id)
 
     async def refresh_if_needed(self) -> bool:
         """Refresh Rexel OAuth2 tokens if needed."""

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -900,7 +900,7 @@ class OverkizClient:
         await self._refresh_token_if_expired()
 
         async with self.session.get(
-            f"{self.server_config.endpoint}{path}",
+            f"{self._auth.endpoint}{path}",
             headers=self._auth.auth_headers(path),
             ssl=self._ssl,
         ) as response:
@@ -916,7 +916,7 @@ class OverkizClient:
         await self._refresh_token_if_expired()
 
         async with self.session.post(
-            f"{self.server_config.endpoint}{path}",
+            f"{self._auth.endpoint}{path}",
             data=data,
             json=payload,
             headers=self._auth.auth_headers(path),
@@ -929,7 +929,7 @@ class OverkizClient:
         await self._refresh_token_if_expired()
 
         async with self.session.put(
-            f"{self.server_config.endpoint}{path}",
+            f"{self._auth.endpoint}{path}",
             json=payload,
             headers=self._auth.auth_headers(path),
             ssl=self._ssl,
@@ -941,7 +941,7 @@ class OverkizClient:
         await self._refresh_token_if_expired()
 
         async with self.session.delete(
-            f"{self.server_config.endpoint}{path}",
+            f"{self._auth.endpoint}{path}",
             headers=self._auth.auth_headers(path),
             ssl=self._ssl,
         ) as response:

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -923,7 +923,7 @@ class OverkizClient:
 
         async with self.session.get(
             f"{self._auth.endpoint}{path}",
-            headers=self._auth.auth_headers(path),
+            headers=await self._auth.auth_headers(path),
             ssl=self._ssl,
         ) as response:
             return await self._parse_response(response)
@@ -941,7 +941,7 @@ class OverkizClient:
             f"{self._auth.endpoint}{path}",
             data=data,
             json=payload,
-            headers=self._auth.auth_headers(path),
+            headers=await self._auth.auth_headers(path),
             ssl=self._ssl,
         ) as response:
             return await self._parse_response(response)
@@ -953,7 +953,7 @@ class OverkizClient:
         async with self.session.put(
             f"{self._auth.endpoint}{path}",
             json=payload,
-            headers=self._auth.auth_headers(path),
+            headers=await self._auth.auth_headers(path),
             ssl=self._ssl,
         ) as response:
             return await self._parse_response(response)
@@ -964,7 +964,7 @@ class OverkizClient:
 
         async with self.session.delete(
             f"{self._auth.endpoint}{path}",
-            headers=self._auth.auth_headers(path),
+            headers=await self._auth.auth_headers(path),
             ssl=self._ssl,
         ) as response:
             await check_response(response)

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -22,7 +22,13 @@ from aiohttp import (
 from backoff.types import Details
 
 from pyoverkiz.action_queue import ActionQueue, ActionQueueSettings
-from pyoverkiz.auth import AuthStrategy, Credentials, build_auth_strategy
+from pyoverkiz.auth import (
+    AuthStrategy,
+    Credentials,
+    GatewayCandidate,
+    SupportsGatewaySelection,
+    build_auth_strategy,
+)
 from pyoverkiz.const import SUPPORTED_SERVERS, USER_AGENT
 from pyoverkiz.converter import converter
 from pyoverkiz.enums import APIType, ExecutionMode, Protocol, Server
@@ -894,6 +900,22 @@ class OverkizClient:
             f"setup/devices/{urllib.parse.quote_plus(device_url)}/manufacturerReferences"
         )
         return converter.structure(response, list[DeviceManufacturerReference])
+
+    async def discover_gateways(self) -> list[GatewayCandidate]:
+        """Discover selectable gateways. Raises TypeError if unsupported."""
+        if not isinstance(self._auth, SupportsGatewaySelection):
+            raise TypeError(
+                f"{self.server_config.name} does not support gateway selection."
+            )
+        return await self._auth.discover_gateways()
+
+    def select_gateway(self, gateway_id: str) -> None:
+        """Select the gateway to scope requests to. Raises TypeError if unsupported."""
+        if not isinstance(self._auth, SupportsGatewaySelection):
+            raise TypeError(
+                f"{self.server_config.name} does not support gateway selection."
+            )
+        self._auth.select_gateway(gateway_id)
 
     async def _get(self, path: str) -> Any:
         """Make a GET request to the OverKiz API."""

--- a/pyoverkiz/const.py
+++ b/pyoverkiz/const.py
@@ -21,15 +21,15 @@ NEXITY_COGNITO_CLIENT_ID = "3mca95jd5ase5lfde65rerovok"
 NEXITY_COGNITO_USER_POOL = "eu-west-1_wj277ucoI"
 NEXITY_COGNITO_REGION = "eu-west-1"
 
-REXEL_BACKEND_API = (
-    "https://app-ec-backend-enduser-prod.azurewebsites.net/api/enduser/overkiz/"
-)
+REXEL_BACKEND_API = "https://econnect-api.rexelservices.fr/"
 REXEL_OAUTH_CLIENT_ID = "2b635ede-c3fb-43bc-8d23-f6d17f80e96d"
+REXEL_OAUTH_REDIRECT_URI = "https://my.home-assistant.io/redirect/oauth"
 REXEL_OAUTH_SCOPE = "https://adb2cservicesfrenduserprod.onmicrosoft.com/94f05108-65f7-477a-a84d-e67e1aed6f79/ExternalProvider"
 REXEL_OAUTH_TENANT = (
     "https://consumerlogin.rexelservices.fr/670998c0-f737-4d75-a32f-ba9292755b70"
 )
-REXEL_OAUTH_POLICY = "B2C_1A_SIGNINONLYHOMEASSISTANT"
+REXEL_OAUTH_POLICY = "b2c_1a_signinonlyhomeassistant"
+REXEL_OAUTH_AUTHORIZE_URL = f"{REXEL_OAUTH_TENANT}/oauth2/v2.0/authorize"
 REXEL_OAUTH_TOKEN_URL = f"{REXEL_OAUTH_TENANT}/oauth2/v2.0/token?p={REXEL_OAUTH_POLICY}"
 REXEL_REQUIRED_CONSENT = "homeassistant"
 

--- a/pyoverkiz/const.py
+++ b/pyoverkiz/const.py
@@ -21,7 +21,10 @@ NEXITY_COGNITO_CLIENT_ID = "3mca95jd5ase5lfde65rerovok"
 NEXITY_COGNITO_USER_POOL = "eu-west-1_wj277ucoI"
 NEXITY_COGNITO_REGION = "eu-west-1"
 
-REXEL_BACKEND_API = "https://econnect-api.rexelservices.fr/api/enduser/overkiz/"
+# Account-wide homes/gateways directory; works before a gateway is selected.
+REXEL_ENDUSER_API = "https://econnect-api.rexelservices.fr/api/enduser"
+# Device (Overkiz-proxy) calls live under /overkiz; gateway-scoped, need the gatewayId header.
+REXEL_BACKEND_API = f"{REXEL_ENDUSER_API}/overkiz/"
 REXEL_OAUTH_CLIENT_ID = "2b635ede-c3fb-43bc-8d23-f6d17f80e96d"
 REXEL_OAUTH_REDIRECT_URI = "https://my.home-assistant.io/redirect/oauth"
 REXEL_OAUTH_SCOPE = "https://adb2cservicesfrenduserprod.onmicrosoft.com/94f05108-65f7-477a-a84d-e67e1aed6f79/ExternalProvider"
@@ -32,9 +35,6 @@ REXEL_OAUTH_POLICY = "b2c_1a_signinonlyhomeassistant"
 REXEL_OAUTH_AUTHORIZE_URL = f"{REXEL_OAUTH_TENANT}/oauth2/v2.0/authorize"
 REXEL_OAUTH_TOKEN_URL = f"{REXEL_OAUTH_TENANT}/oauth2/v2.0/token?p={REXEL_OAUTH_POLICY}"
 REXEL_REQUIRED_CONSENT = "homeassistant"
-# The homes/gateways directory lives one level up from the device API base
-# (REXEL_BACKEND_API ends in .../overkiz/; directory calls are at .../enduser).
-REXEL_ENDUSER_API = REXEL_BACKEND_API.rsplit("/overkiz/", 1)[0]
 REXEL_GATEWAY_HEADER = "gatewayId"
 
 SOMFY_API = "https://accounts.somfy.com"

--- a/pyoverkiz/const.py
+++ b/pyoverkiz/const.py
@@ -21,7 +21,7 @@ NEXITY_COGNITO_CLIENT_ID = "3mca95jd5ase5lfde65rerovok"
 NEXITY_COGNITO_USER_POOL = "eu-west-1_wj277ucoI"
 NEXITY_COGNITO_REGION = "eu-west-1"
 
-REXEL_BACKEND_API = "https://econnect-api.rexelservices.fr/"
+REXEL_BACKEND_API = "https://econnect-api.rexelservices.fr/overkiz/"
 REXEL_OAUTH_CLIENT_ID = "2b635ede-c3fb-43bc-8d23-f6d17f80e96d"
 REXEL_OAUTH_REDIRECT_URI = "https://my.home-assistant.io/redirect/oauth"
 REXEL_OAUTH_SCOPE = "https://adb2cservicesfrenduserprod.onmicrosoft.com/94f05108-65f7-477a-a84d-e67e1aed6f79/ExternalProvider"
@@ -32,6 +32,10 @@ REXEL_OAUTH_POLICY = "b2c_1a_signinonlyhomeassistant"
 REXEL_OAUTH_AUTHORIZE_URL = f"{REXEL_OAUTH_TENANT}/oauth2/v2.0/authorize"
 REXEL_OAUTH_TOKEN_URL = f"{REXEL_OAUTH_TENANT}/oauth2/v2.0/token?p={REXEL_OAUTH_POLICY}"
 REXEL_REQUIRED_CONSENT = "homeassistant"
+# The homes/gateways directory lives one level up from the device API base
+# (REXEL_BACKEND_API ends in .../overkiz/; directory calls are at .../enduser).
+REXEL_ENDUSER_API = REXEL_BACKEND_API.rsplit("/overkiz/", 1)[0]
+REXEL_GATEWAY_HEADER = "gatewayId"
 
 SOMFY_API = "https://accounts.somfy.com"
 SOMFY_CLIENT_ID = "0d8e920c-1478-11e7-a377-02dd59bd3041_1ewvaqmclfogo4kcsoo0c8k4kso884owg08sg8c40sk4go4ksg"

--- a/pyoverkiz/const.py
+++ b/pyoverkiz/const.py
@@ -21,7 +21,7 @@ NEXITY_COGNITO_CLIENT_ID = "3mca95jd5ase5lfde65rerovok"
 NEXITY_COGNITO_USER_POOL = "eu-west-1_wj277ucoI"
 NEXITY_COGNITO_REGION = "eu-west-1"
 
-REXEL_BACKEND_API = "https://econnect-api.rexelservices.fr/overkiz/"
+REXEL_BACKEND_API = "https://econnect-api.rexelservices.fr/api/enduser/overkiz/"
 REXEL_OAUTH_CLIENT_ID = "2b635ede-c3fb-43bc-8d23-f6d17f80e96d"
 REXEL_OAUTH_REDIRECT_URI = "https://my.home-assistant.io/redirect/oauth"
 REXEL_OAUTH_SCOPE = "https://adb2cservicesfrenduserprod.onmicrosoft.com/94f05108-65f7-477a-a84d-e67e1aed6f79/ExternalProvider"

--- a/pyoverkiz/exceptions.py
+++ b/pyoverkiz/exceptions.py
@@ -89,6 +89,10 @@ class InvalidTokenError(BaseOverkizError):
     """Raised when an invalid token is provided."""
 
 
+class NoGatewaySelectedError(BaseOverkizError):
+    """No gateway selected for a server that requires gateway selection."""
+
+
 class NoSuchTokenError(BaseOverkizError):
     """Raised when no such token exists."""
 

--- a/pyoverkiz/pkce.py
+++ b/pyoverkiz/pkce.py
@@ -1,0 +1,62 @@
+"""Utilities for OAuth2 PKCE (Proof Key for Code Exchange) flow."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+
+
+def generate_code_verifier(length: int = 64) -> str:
+    """Generate a cryptographically random code verifier for PKCE.
+
+    The code verifier is a high-entropy cryptographic random string using
+    unreserved characters [A-Z] / [a-z] / [0-9] / "-" / "." / "_" / "~",
+    with a minimum length of 43 characters and a maximum length of 128.
+
+    Args:
+        length: Number of random bytes to generate (default 64, resulting in ~86 chars)
+
+    Returns:
+        Base64 URL-safe encoded string without padding
+    """
+    if length < 32 or length > 96:
+        raise ValueError("Length must be between 32 and 96 bytes")
+
+    code_verifier = base64.urlsafe_b64encode(secrets.token_bytes(length)).decode(
+        "utf-8"
+    )
+    # Remove padding as per RFC 7636
+    return code_verifier.rstrip("=")
+
+
+def generate_code_challenge(code_verifier: str) -> str:
+    """Generate the code challenge from a code verifier using S256 method.
+
+    As per RFC 7636, the code challenge is the Base64 URL-encoded SHA-256
+    hash of the code verifier.
+
+    Args:
+        code_verifier: The code verifier string
+
+    Returns:
+        Base64 URL-safe encoded SHA-256 hash without padding
+    """
+    code_challenge_bytes = hashlib.sha256(code_verifier.encode("utf-8")).digest()
+    code_challenge = base64.urlsafe_b64encode(code_challenge_bytes).decode("utf-8")
+    # Remove padding as per RFC 7636
+    return code_challenge.rstrip("=")
+
+
+def generate_pkce_pair(verifier_length: int = 64) -> tuple[str, str]:
+    """Generate both PKCE code verifier and code challenge.
+
+    Args:
+        verifier_length: Number of random bytes for the verifier (default 64)
+
+    Returns:
+        Tuple of (code_verifier, code_challenge)
+    """
+    code_verifier = generate_code_verifier(verifier_length)
+    code_challenge = generate_code_challenge(code_verifier)
+    return code_verifier, code_challenge

--- a/pyoverkiz/pkce.py
+++ b/pyoverkiz/pkce.py
@@ -6,6 +6,11 @@ import base64
 import hashlib
 import secrets
 
+# Bounds for the number of random bytes used to build a PKCE code verifier.
+# 32 bytes -> ~43 chars (RFC 7636 minimum); 96 bytes -> ~128 chars (maximum).
+MIN_CODE_VERIFIER_BYTES = 32
+MAX_CODE_VERIFIER_BYTES = 96
+
 
 def generate_code_verifier(length: int = 64) -> str:
     """Generate a cryptographically random code verifier for PKCE.
@@ -20,8 +25,11 @@ def generate_code_verifier(length: int = 64) -> str:
     Returns:
         Base64 URL-safe encoded string without padding
     """
-    if length < 32 or length > 96:
-        raise ValueError("Length must be between 32 and 96 bytes")
+    if length < MIN_CODE_VERIFIER_BYTES or length > MAX_CODE_VERIFIER_BYTES:
+        raise ValueError(
+            f"Length must be between {MIN_CODE_VERIFIER_BYTES} and "
+            f"{MAX_CODE_VERIFIER_BYTES} bytes"
+        )
 
     code_verifier = base64.urlsafe_b64encode(secrets.token_bytes(length)).decode(
         "utf-8"

--- a/pyoverkiz/utils.py
+++ b/pyoverkiz/utils.py
@@ -3,8 +3,16 @@
 from __future__ import annotations
 
 import re
+import urllib.parse
 
-from pyoverkiz.const import LOCAL_API_PATH
+from pyoverkiz.const import (
+    LOCAL_API_PATH,
+    REXEL_OAUTH_AUTHORIZE_URL,
+    REXEL_OAUTH_CLIENT_ID,
+    REXEL_OAUTH_POLICY,
+    REXEL_OAUTH_REDIRECT_URI,
+    REXEL_OAUTH_SCOPE,
+)
 from pyoverkiz.enums.server import APIType, Server
 from pyoverkiz.models import ServerConfig
 
@@ -54,3 +62,36 @@ def create_server_config(
 def is_overkiz_gateway(gateway_id: str) -> bool:
     """Return if gateway is Overkiz gateway. Can be used to distinguish between the main gateway and an additional gateway."""
     return bool(re.match(r"\d{4}-\d{4}-\d{4}", gateway_id))
+
+
+def build_rexel_authorization_url(
+    code_challenge: str,
+    state: str | None = None,
+    redirect_uri: str | None = None,
+) -> str:
+    """Build the Rexel OAuth2 authorization URL with PKCE parameters.
+
+    Args:
+        code_challenge: The PKCE code challenge (SHA-256 hash of code_verifier)
+        state: Optional state parameter for CSRF protection
+        redirect_uri: Optional redirect URI (defaults to REXEL_OAUTH_REDIRECT_URI)
+
+    Returns:
+        Complete authorization URL
+    """
+    params = {
+        "p": REXEL_OAUTH_POLICY,
+        "client_id": REXEL_OAUTH_CLIENT_ID,
+        "response_type": "code",
+        "redirect_uri": redirect_uri or REXEL_OAUTH_REDIRECT_URI,
+        "response_mode": "query",
+        "scope": REXEL_OAUTH_SCOPE,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+
+    if state:
+        params["state"] = state
+
+    query_string = urllib.parse.urlencode(params)
+    return f"{REXEL_OAUTH_AUTHORIZE_URL}?{query_string}"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -812,3 +812,42 @@ def test_rexel_auth_headers_empty_without_token():
     strategy.context.access_token = None
 
     assert strategy.auth_headers() == {}
+
+
+@pytest.mark.asyncio
+async def test_rexel_login_auto_selects_single_gateway():
+    """Login auto-selects the only gateway when exactly one is found."""
+    from unittest.mock import AsyncMock
+
+    from pyoverkiz.auth.base import GatewayCandidate
+
+    strategy, _ = _build_rexel_strategy_with_token([])
+    strategy._exchange_token = AsyncMock(return_value=None)
+    strategy.discover_gateways = AsyncMock(
+        return_value=[GatewayCandidate(gateway_id="only-one")]
+    )
+
+    await strategy.login()
+
+    assert strategy.selected_gateway == "only-one"
+
+
+@pytest.mark.asyncio
+async def test_rexel_login_does_not_auto_select_multiple_gateways():
+    """Login leaves selection unset when multiple gateways are found."""
+    from unittest.mock import AsyncMock
+
+    from pyoverkiz.auth.base import GatewayCandidate
+
+    strategy, _ = _build_rexel_strategy_with_token([])
+    strategy._exchange_token = AsyncMock(return_value=None)
+    strategy.discover_gateways = AsyncMock(
+        return_value=[
+            GatewayCandidate(gateway_id="a"),
+            GatewayCandidate(gateway_id="b"),
+        ]
+    )
+
+    await strategy.login()
+
+    assert strategy.selected_gateway is None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -664,24 +664,29 @@ def test_base_strategy_endpoint_defaults_to_server_endpoint():
 
 
 def test_gateway_candidate_fields():
-    """GatewayCandidate holds gateway_id with optional home_id and label."""
+    """GatewayCandidate holds gateway_id with optional home_id, label, external_id."""
     from pyoverkiz.auth.base import GatewayCandidate
 
     candidate = GatewayCandidate(
-        gateway_id="1234-5678-9012", home_id="home-1", label="Living room"
+        gateway_id="42760",
+        home_id="44571",
+        label="Demo",
+        external_id="0201-0012-0000",
     )
-    assert candidate.gateway_id == "1234-5678-9012"
-    assert candidate.home_id == "home-1"
-    assert candidate.label == "Living room"
+    assert candidate.gateway_id == "42760"
+    assert candidate.home_id == "44571"
+    assert candidate.label == "Demo"
+    assert candidate.external_id == "0201-0012-0000"
 
 
 def test_gateway_candidate_optional_fields_default_none():
-    """home_id and label default to None."""
+    """home_id, label and external_id default to None."""
     from pyoverkiz.auth.base import GatewayCandidate
 
     candidate = GatewayCandidate(gateway_id="g1")
     assert candidate.home_id is None
     assert candidate.label is None
+    assert candidate.external_id is None
 
 
 def test_no_gateway_selected_error_is_overkiz_error():
@@ -699,6 +704,82 @@ def test_rexel_enduser_api_strips_overkiz_suffix():
         REXEL_GATEWAY_HEADER,
     )
 
-    assert REXEL_ENDUSER_API == REXEL_BACKEND_API.rsplit("/overkiz/", 1)[0]
+    # Device control goes to .../api/enduser/overkiz/{command};
+    # the homes/gateways directory lives at .../api/enduser.
+    assert (
+        REXEL_BACKEND_API
+        == "https://econnect-api.rexelservices.fr/api/enduser/overkiz/"
+    )
+    assert REXEL_ENDUSER_API == "https://econnect-api.rexelservices.fr/api/enduser"
+    assert REXEL_BACKEND_API.rsplit("/overkiz/", 1)[0] == REXEL_ENDUSER_API
     assert not REXEL_ENDUSER_API.endswith("/")
     assert REXEL_GATEWAY_HEADER == "gatewayId"
+
+
+def _build_rexel_strategy_with_token(json_bodies):
+    """Return a RexelAuthStrategy with a fake token and a session.
+
+    json_bodies (a list) are returned in order from session.get().
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from aiohttp import ClientSession
+
+    from pyoverkiz.auth.credentials import RexelOAuthCodeCredentials
+    from pyoverkiz.auth.strategies import RexelAuthStrategy
+    from pyoverkiz.enums.server import APIType
+    from pyoverkiz.models import ServerConfig
+
+    server = ServerConfig(
+        server=None,
+        name="Rexel",
+        endpoint="https://econnect-api.rexelservices.fr/api/enduser/overkiz/",
+        manufacturer="Rexel",
+        api_type=APIType.CLOUD,
+    )
+    session = MagicMock(spec=ClientSession)
+
+    responses = []
+    for body in json_bodies:
+        resp = MagicMock()
+        resp.status = 200
+        resp.json = AsyncMock(return_value=body)
+        resp.text = AsyncMock(return_value="")
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=resp)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        responses.append(ctx)
+    session.get = MagicMock(side_effect=responses)
+
+    strategy = RexelAuthStrategy(
+        credentials=RexelOAuthCodeCredentials("code", "uri", "verifier"),
+        session=session,
+        server=server,
+        ssl_context=True,
+    )
+    strategy.context.access_token = "fake-jwt"
+    return strategy, session
+
+
+@pytest.mark.asyncio
+async def test_rexel_discover_gateways_flattens_homes_and_gateways():
+    """discover_gateways returns one GatewayCandidate per gateway across homes."""
+    strategy, _ = _build_rexel_strategy_with_token(
+        [
+            [{"id": 44571, "label": "Demo"}],  # GET /homes (id is an int)
+            [  # GET /overkizgateways?homeId=44571
+                {"gatewayId": 42760, "externalId": "0201-0012-0000"},
+                {"gatewayId": 99999, "externalId": "0201-0012-9999"},
+            ],
+        ]
+    )
+
+    candidates = await strategy.discover_gateways()
+
+    assert len(candidates) == 2
+    assert candidates[0].gateway_id == "42760"
+    assert candidates[0].home_id == "44571"
+    assert candidates[0].label == "Demo"
+    assert candidates[0].external_id == "0201-0012-0000"
+    assert candidates[1].gateway_id == "99999"
+    assert candidates[1].external_id == "0201-0012-9999"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -37,7 +37,11 @@ from pyoverkiz.auth.strategies import (
     _decode_jwt_payload,
 )
 from pyoverkiz.enums import APIType, Server
-from pyoverkiz.exceptions import InvalidTokenError, NexityBadCredentialsError
+from pyoverkiz.exceptions import (
+    InvalidTokenError,
+    NexityBadCredentialsError,
+    NoGatewaySelectedError,
+)
 from pyoverkiz.models import ServerConfig
 
 HAS_NEXITY_DEPS = importlib.util.find_spec("boto3") is not None
@@ -691,7 +695,7 @@ def test_gateway_candidate_optional_fields_default_none():
 
 def test_no_gateway_selected_error_is_overkiz_error():
     """NoGatewaySelectedError subclasses BaseOverkizError."""
-    from pyoverkiz.exceptions import BaseOverkizError, NoGatewaySelectedError
+    from pyoverkiz.exceptions import BaseOverkizError
 
     assert issubclass(NoGatewaySelectedError, BaseOverkizError)
 
@@ -785,6 +789,31 @@ async def test_rexel_discover_gateways_flattens_homes_and_gateways():
     assert candidates[1].external_id == "0201-0012-9999"
 
 
+@pytest.mark.asyncio
+async def test_rexel_discover_gateways_empty_when_no_homes():
+    """discover_gateways returns [] when the account has no homes."""
+    strategy, _ = _build_rexel_strategy_with_token([[]])  # GET /homes -> []
+
+    assert await strategy.discover_gateways() == []
+
+
+@pytest.mark.asyncio
+async def test_rexel_login_with_no_gateways_leaves_unselected():
+    """Login does not select anything when discovery yields zero gateways."""
+    from unittest.mock import AsyncMock
+
+    strategy, _ = _build_rexel_strategy_with_token([])
+    strategy._exchange_token = AsyncMock(return_value=None)
+    strategy.discover_gateways = AsyncMock(return_value=[])
+
+    await strategy.login()
+
+    assert strategy.selected_gateway is None
+    # A subsequent device request must then fail loudly rather than silently.
+    with pytest.raises(NoGatewaySelectedError):
+        strategy.auth_headers()
+
+
 def test_rexel_auth_headers_includes_gateway_when_selected():
     """auth_headers includes Authorization and gatewayId after selection."""
     strategy, _ = _build_rexel_strategy_with_token([])
@@ -798,8 +827,6 @@ def test_rexel_auth_headers_includes_gateway_when_selected():
 
 def test_rexel_auth_headers_raises_when_unselected():
     """auth_headers raises NoGatewaySelectedError when no gateway is selected."""
-    from pyoverkiz.exceptions import NoGatewaySelectedError
-
     strategy, _ = _build_rexel_strategy_with_token([])
 
     with pytest.raises(NoGatewaySelectedError):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -661,3 +661,24 @@ def test_base_strategy_endpoint_defaults_to_server_endpoint():
         ssl_context=True,
     )
     assert strategy.endpoint == "https://example.test/api/"
+
+
+def test_gateway_candidate_fields():
+    """GatewayCandidate holds gateway_id with optional home_id and label."""
+    from pyoverkiz.auth.base import GatewayCandidate
+
+    candidate = GatewayCandidate(
+        gateway_id="1234-5678-9012", home_id="home-1", label="Living room"
+    )
+    assert candidate.gateway_id == "1234-5678-9012"
+    assert candidate.home_id == "home-1"
+    assert candidate.label == "Living room"
+
+
+def test_gateway_candidate_optional_fields_default_none():
+    """home_id and label default to None."""
+    from pyoverkiz.auth.base import GatewayCandidate
+
+    candidate = GatewayCandidate(gateway_id="g1")
+    assert candidate.home_id is None
+    assert candidate.label is None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -962,6 +962,13 @@ def test_auth_package_exports_gateway_selection_types():
     assert SupportsGatewaySelection is not None
 
 
+def test_auth_package_exports_rexel_token_credentials():
+    """RexelTokenCredentials is importable from pyoverkiz.auth."""
+    from pyoverkiz.auth import RexelTokenCredentials
+
+    assert RexelTokenCredentials is not None
+
+
 def _build_rexel_token_strategy(json_bodies, *, credentials):
     """Return a RexelTokenAuthStrategy whose session.get yields json_bodies."""
     from unittest.mock import AsyncMock, MagicMock

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -19,6 +19,7 @@ from pyoverkiz.auth.base import AuthContext
 from pyoverkiz.auth.credentials import (
     LocalTokenCredentials,
     RexelOAuthCodeCredentials,
+    RexelTokenCredentials,
     TokenCredentials,
     UsernamePasswordCredentials,
 )
@@ -112,6 +113,29 @@ class TestCredentials:
         assert creds.code == "auth_code_xyz"
         assert creds.redirect_uri == "http://redirect.uri"
         assert creds.code_verifier == "code_verifier_123"
+
+    def test_rexel_token_credentials_with_static_token(self):
+        """RexelTokenCredentials accepts a static access token."""
+        creds = RexelTokenCredentials(access_token="static-token")
+        assert creds.access_token == "static-token"
+        assert creds.access_token_callback is None
+        assert creds.gateway_id is None
+
+    def test_rexel_token_credentials_with_callback(self):
+        """RexelTokenCredentials accepts an async access-token callback."""
+
+        async def _token() -> str:
+            return "fresh-token"
+
+        creds = RexelTokenCredentials(access_token_callback=_token, gateway_id="g1")
+        assert creds.access_token_callback is _token
+        assert creds.gateway_id == "g1"
+        assert creds.access_token is None
+
+    def test_rexel_token_credentials_requires_a_token_source(self):
+        """Constructing with neither callback nor static token raises ValueError."""
+        with pytest.raises(ValueError, match="access_token_callback or access_token"):
+            RexelTokenCredentials()
 
 
 class TestAuthFactory:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -33,6 +33,7 @@ from pyoverkiz.auth.strategies import (
     LocalTokenAuthStrategy,
     NexityAuthStrategy,
     RexelAuthStrategy,
+    RexelTokenAuthStrategy,
     SessionLoginStrategy,
     SomfyAuthStrategy,
     _decode_jwt_payload,
@@ -915,3 +916,167 @@ def test_auth_package_exports_gateway_selection_types():
 
     assert GatewayCandidate is not None
     assert SupportsGatewaySelection is not None
+
+
+def _build_rexel_token_strategy(json_bodies, *, credentials):
+    """Return a RexelTokenAuthStrategy whose session.get yields json_bodies."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from aiohttp import ClientSession
+
+    from pyoverkiz.enums.server import APIType
+    from pyoverkiz.models import ServerConfig
+
+    server = ServerConfig(
+        server=None,
+        name="Rexel",
+        endpoint="https://econnect-api.rexelservices.fr/api/enduser/overkiz/",
+        manufacturer="Rexel",
+        api_type=APIType.CLOUD,
+    )
+    session = MagicMock(spec=ClientSession)
+
+    responses = []
+    for body in json_bodies:
+        resp = MagicMock()
+        resp.status = 200
+        resp.json = AsyncMock(return_value=body)
+        resp.text = AsyncMock(return_value="")
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=resp)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        responses.append(ctx)
+    session.get = MagicMock(side_effect=responses)
+
+    strategy = RexelTokenAuthStrategy(
+        credentials=credentials,
+        session=session,
+        server=server,
+        ssl_context=True,
+    )
+    return strategy, session
+
+
+@pytest.mark.asyncio
+async def test_rexel_token_auth_headers_uses_static_token():
+    """auth_headers builds Bearer + gatewayId from a static access token."""
+    creds = RexelTokenCredentials(access_token="static-token")
+    strategy, _ = _build_rexel_token_strategy([], credentials=creds)
+    strategy.select_gateway("gw-1")
+
+    headers = await strategy.auth_headers()
+
+    assert headers["Authorization"] == "Bearer static-token"
+    assert headers["gatewayId"] == "gw-1"
+
+
+@pytest.mark.asyncio
+async def test_rexel_token_auth_headers_invokes_callback():
+    """auth_headers awaits the callback to obtain a fresh token each call."""
+    calls = []
+
+    async def _token() -> str:
+        calls.append(1)
+        return f"token-{len(calls)}"
+
+    creds = RexelTokenCredentials(access_token_callback=_token)
+    strategy, _ = _build_rexel_token_strategy([], credentials=creds)
+    strategy.select_gateway("gw-1")
+
+    first = await strategy.auth_headers()
+    second = await strategy.auth_headers()
+
+    # Callback is re-invoked per request: proves no caching / no staleness.
+    assert first["Authorization"] == "Bearer token-1"
+    assert second["Authorization"] == "Bearer token-2"
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_rexel_token_auth_headers_raises_when_unselected():
+    """auth_headers raises NoGatewaySelectedError before a gateway is chosen."""
+    creds = RexelTokenCredentials(access_token="static-token")
+    strategy, _ = _build_rexel_token_strategy([], credentials=creds)
+
+    with pytest.raises(NoGatewaySelectedError):
+        await strategy.auth_headers()
+
+
+@pytest.mark.asyncio
+async def test_rexel_token_login_applies_stored_gateway_without_discovery():
+    """login() with credentials.gateway_id selects it and skips discovery."""
+    creds = RexelTokenCredentials(access_token="static-token", gateway_id="stored-gw")
+    # No json bodies: discovery would raise StopIteration on session.get if called.
+    strategy, session = _build_rexel_token_strategy([], credentials=creds)
+
+    await strategy.login()
+
+    assert strategy.selected_gateway == "stored-gw"
+    session.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rexel_token_login_auto_selects_single_gateway():
+    """login() without a stored gateway auto-selects a sole discovered gateway."""
+    creds = RexelTokenCredentials(access_token="static-token")
+    strategy, _ = _build_rexel_token_strategy(
+        [
+            [{"id": 1, "label": "Home"}],  # GET /homes
+            [{"gatewayId": "only-gw", "externalId": "x"}],  # GET /overkizgateways
+        ],
+        credentials=creds,
+    )
+
+    await strategy.login()
+
+    assert strategy.selected_gateway == "only-gw"
+
+
+@pytest.mark.asyncio
+async def test_rexel_token_login_leaves_multiple_unselected():
+    """login() leaves selection unset when several gateways are discovered."""
+    creds = RexelTokenCredentials(access_token="static-token")
+    strategy, _ = _build_rexel_token_strategy(
+        [
+            [{"id": 1, "label": "Home"}],  # GET /homes
+            [  # GET /overkizgateways
+                {"gatewayId": "a", "externalId": "x"},
+                {"gatewayId": "b", "externalId": "y"},
+            ],
+        ],
+        credentials=creds,
+    )
+
+    await strategy.login()
+
+    assert strategy.selected_gateway is None
+
+
+@pytest.mark.asyncio
+async def test_rexel_token_discovery_uses_callback_token():
+    """discover_gateways works using the callback-supplied token."""
+
+    async def _token() -> str:
+        return "callback-token"
+
+    creds = RexelTokenCredentials(access_token_callback=_token)
+    strategy, _ = _build_rexel_token_strategy(
+        [
+            [{"id": 7, "label": "H"}],
+            [{"gatewayId": "g7", "externalId": "e7"}],
+        ],
+        credentials=creds,
+    )
+
+    candidates = await strategy.discover_gateways()
+
+    assert [c.gateway_id for c in candidates] == ["g7"]
+
+
+def test_rexel_token_strategy_supports_gateway_selection():
+    """RexelTokenAuthStrategy satisfies the SupportsGatewaySelection protocol."""
+    from pyoverkiz.auth import SupportsGatewaySelection
+
+    creds = RexelTokenCredentials(access_token="static-token")
+    strategy, _ = _build_rexel_token_strategy([], credentials=creds)
+    assert isinstance(strategy, SupportsGatewaySelection)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -783,3 +783,32 @@ async def test_rexel_discover_gateways_flattens_homes_and_gateways():
     assert candidates[0].external_id == "0201-0012-0000"
     assert candidates[1].gateway_id == "99999"
     assert candidates[1].external_id == "0201-0012-9999"
+
+
+def test_rexel_auth_headers_includes_gateway_when_selected():
+    """auth_headers includes Authorization and gatewayId after selection."""
+    strategy, _ = _build_rexel_strategy_with_token([])
+    strategy.select_gateway("1111-2222-3333")
+
+    headers = strategy.auth_headers()
+
+    assert headers["Authorization"] == "Bearer fake-jwt"
+    assert headers["gatewayId"] == "1111-2222-3333"
+
+
+def test_rexel_auth_headers_raises_when_unselected():
+    """auth_headers raises NoGatewaySelectedError when no gateway is selected."""
+    from pyoverkiz.exceptions import NoGatewaySelectedError
+
+    strategy, _ = _build_rexel_strategy_with_token([])
+
+    with pytest.raises(NoGatewaySelectedError):
+        strategy.auth_headers()
+
+
+def test_rexel_auth_headers_empty_without_token():
+    """auth_headers returns empty mapping before login (no token)."""
+    strategy, _ = _build_rexel_strategy_with_token([])
+    strategy.context.access_token = None
+
+    assert strategy.auth_headers() == {}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -689,3 +689,16 @@ def test_no_gateway_selected_error_is_overkiz_error():
     from pyoverkiz.exceptions import BaseOverkizError, NoGatewaySelectedError
 
     assert issubclass(NoGatewaySelectedError, BaseOverkizError)
+
+
+def test_rexel_enduser_api_strips_overkiz_suffix():
+    """REXEL_ENDUSER_API points one level up from the overkiz device base."""
+    from pyoverkiz.const import (
+        REXEL_BACKEND_API,
+        REXEL_ENDUSER_API,
+        REXEL_GATEWAY_HEADER,
+    )
+
+    assert REXEL_ENDUSER_API == REXEL_BACKEND_API.rsplit("/overkiz/", 1)[0]
+    assert not REXEL_ENDUSER_API.endswith("/")
+    assert REXEL_GATEWAY_HEADER == "gatewayId"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -455,7 +455,8 @@ class TestSessionLoginStrategy:
 
         assert not result
 
-    def test_auth_headers_no_token(self):
+    @pytest.mark.asyncio
+    async def test_auth_headers_no_token(self):
         """Test that auth headers return empty dict when no token."""
         server_config = ServerConfig(
             server=Server.SOMFY_OCEANIA,
@@ -468,7 +469,7 @@ class TestSessionLoginStrategy:
         session = AsyncMock(spec=ClientSession)
 
         strategy = SessionLoginStrategy(credentials, session, server_config, True)
-        headers = strategy.auth_headers()
+        headers = await strategy.auth_headers()
 
         assert headers == {}
 
@@ -495,7 +496,8 @@ class TestBearerTokenAuthStrategy:
         # Login should be a no-op
         assert result is None
 
-    def test_auth_headers_with_token(self):
+    @pytest.mark.asyncio
+    async def test_auth_headers_with_token(self):
         """Test that auth headers include Bearer token."""
         server_config = ServerConfig(
             server=None,
@@ -508,7 +510,7 @@ class TestBearerTokenAuthStrategy:
         session = AsyncMock(spec=ClientSession)
 
         strategy = BearerTokenAuthStrategy(credentials, session, server_config, True)
-        headers = strategy.auth_headers()
+        headers = await strategy.auth_headers()
 
         assert headers == {"Authorization": "Bearer my_bearer_token"}
 
@@ -835,34 +837,37 @@ async def test_rexel_login_with_no_gateways_leaves_unselected():
     assert strategy.selected_gateway is None
     # A subsequent device request must then fail loudly rather than silently.
     with pytest.raises(NoGatewaySelectedError):
-        strategy.auth_headers()
+        await strategy.auth_headers()
 
 
-def test_rexel_auth_headers_includes_gateway_when_selected():
+@pytest.mark.asyncio
+async def test_rexel_auth_headers_includes_gateway_when_selected():
     """auth_headers includes Authorization and gatewayId after selection."""
     strategy, _ = _build_rexel_strategy_with_token([])
     strategy.select_gateway("1111-2222-3333")
 
-    headers = strategy.auth_headers()
+    headers = await strategy.auth_headers()
 
     assert headers["Authorization"] == "Bearer fake-jwt"
     assert headers["gatewayId"] == "1111-2222-3333"
 
 
-def test_rexel_auth_headers_raises_when_unselected():
+@pytest.mark.asyncio
+async def test_rexel_auth_headers_raises_when_unselected():
     """auth_headers raises NoGatewaySelectedError when no gateway is selected."""
     strategy, _ = _build_rexel_strategy_with_token([])
 
     with pytest.raises(NoGatewaySelectedError):
-        strategy.auth_headers()
+        await strategy.auth_headers()
 
 
-def test_rexel_auth_headers_empty_without_token():
+@pytest.mark.asyncio
+async def test_rexel_auth_headers_empty_without_token():
     """auth_headers returns empty mapping before login (no token)."""
     strategy, _ = _build_rexel_strategy_with_token([])
     strategy.context.access_token = None
 
-    assert strategy.auth_headers() == {}
+    assert await strategy.auth_headers() == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -682,3 +682,10 @@ def test_gateway_candidate_optional_fields_default_none():
     candidate = GatewayCandidate(gateway_id="g1")
     assert candidate.home_id is None
     assert candidate.label is None
+
+
+def test_no_gateway_selected_error_is_overkiz_error():
+    """NoGatewaySelectedError subclasses BaseOverkizError."""
+    from pyoverkiz.exceptions import BaseOverkizError, NoGatewaySelectedError
+
+    assert issubclass(NoGatewaySelectedError, BaseOverkizError)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -275,6 +275,50 @@ class TestAuthFactory:
         assert isinstance(strategy, RexelAuthStrategy)
 
     @pytest.mark.asyncio
+    async def test_build_auth_strategy_rexel_token(self):
+        """RexelTokenCredentials build a RexelTokenAuthStrategy for Rexel."""
+        server_config = ServerConfig(
+            server=Server.REXEL,
+            name="Rexel",
+            endpoint="https://api.rexel.com",
+            manufacturer="Rexel",
+            api_type=APIType.CLOUD,
+        )
+        credentials = RexelTokenCredentials(access_token="static-token")
+        session = AsyncMock(spec=ClientSession)
+
+        strategy = build_auth_strategy(
+            server_config=server_config,
+            credentials=credentials,
+            session=session,
+            ssl_context=True,
+        )
+
+        assert isinstance(strategy, RexelTokenAuthStrategy)
+
+    @pytest.mark.asyncio
+    async def test_build_auth_strategy_rexel_code_still_works(self):
+        """RexelOAuthCodeCredentials still build the code-exchange strategy."""
+        server_config = ServerConfig(
+            server=Server.REXEL,
+            name="Rexel",
+            endpoint="https://api.rexel.com",
+            manufacturer="Rexel",
+            api_type=APIType.CLOUD,
+        )
+        credentials = RexelOAuthCodeCredentials("code", "uri", "verifier")
+        session = AsyncMock(spec=ClientSession)
+
+        strategy = build_auth_strategy(
+            server_config=server_config,
+            credentials=credentials,
+            session=session,
+            ssl_context=True,
+        )
+
+        assert isinstance(strategy, RexelAuthStrategy)
+
+    @pytest.mark.asyncio
     async def test_build_auth_strategy_local_token(self):
         """Test building local token auth strategy."""
         server_config = ServerConfig(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -102,9 +102,12 @@ class TestCredentials:
 
     def test_rexel_oauth_credentials(self):
         """Test RexelOAuthCodeCredentials creation."""
-        creds = RexelOAuthCodeCredentials("auth_code_xyz", "http://redirect.uri")
+        creds = RexelOAuthCodeCredentials(
+            "auth_code_xyz", "http://redirect.uri", "code_verifier_123"
+        )
         assert creds.code == "auth_code_xyz"
         assert creds.redirect_uri == "http://redirect.uri"
+        assert creds.code_verifier == "code_verifier_123"
 
 
 class TestAuthFactory:
@@ -142,7 +145,7 @@ class TestAuthFactory:
 
     def test_ensure_credentials_rexel_valid(self):
         """Test that valid Rexel credentials pass validation."""
-        creds = RexelOAuthCodeCredentials("code", "uri")
+        creds = RexelOAuthCodeCredentials("code", "uri", "verifier")
         result = _ensure_credentials(creds, RexelOAuthCodeCredentials)
         assert result is creds
 
@@ -228,7 +231,9 @@ class TestAuthFactory:
             manufacturer="Rexel",
             api_type=APIType.CLOUD,
         )
-        credentials = RexelOAuthCodeCredentials("code", "http://redirect.uri")
+        credentials = RexelOAuthCodeCredentials(
+            "code", "http://redirect.uri", "verifier"
+        )
         session = AsyncMock(spec=ClientSession)
 
         strategy = build_auth_strategy(
@@ -596,7 +601,9 @@ class TestRexelAuthStrategy:
             manufacturer="Rexel",
             api_type=APIType.CLOUD,
         )
-        credentials = RexelOAuthCodeCredentials("code", "https://redirect")
+        credentials = RexelOAuthCodeCredentials(
+            "code", "https://redirect", "code_verifier_value"
+        )
         session = AsyncMock(spec=ClientSession)
 
         mock_response = MagicMock()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -851,3 +851,11 @@ async def test_rexel_login_does_not_auto_select_multiple_gateways():
     await strategy.login()
 
     assert strategy.selected_gateway is None
+
+
+def test_auth_package_exports_gateway_selection_types():
+    """GatewayCandidate and SupportsGatewaySelection are exported from auth."""
+    from pyoverkiz.auth import GatewayCandidate, SupportsGatewaySelection
+
+    assert GatewayCandidate is not None
+    assert SupportsGatewaySelection is not None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -636,3 +636,28 @@ class TestRexelAuthStrategy:
         """Malformed tokens raise InvalidTokenError during decoding."""
         with pytest.raises(InvalidTokenError):
             _decode_jwt_payload("invalid.token")
+
+
+def test_base_strategy_endpoint_defaults_to_server_endpoint():
+    """Endpoint property defaults to the server config endpoint."""
+    from unittest.mock import AsyncMock
+
+    from aiohttp import ClientSession
+
+    from pyoverkiz.auth.strategies import BaseAuthStrategy
+    from pyoverkiz.enums.server import APIType
+    from pyoverkiz.models import ServerConfig
+
+    server = ServerConfig(
+        server=None,
+        name="Test",
+        endpoint="https://example.test/api/",
+        manufacturer="Test",
+        api_type=APIType.CLOUD,
+    )
+    strategy = BaseAuthStrategy(
+        session=AsyncMock(spec=ClientSession),
+        server=server,
+        ssl_context=True,
+    )
+    assert strategy.endpoint == "https://example.test/api/"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,7 +11,11 @@ import pytest
 
 from pyoverkiz import exceptions
 from pyoverkiz.action_queue import ActionQueueSettings
-from pyoverkiz.auth import UsernamePasswordCredentials
+from pyoverkiz.auth import (
+    GatewayCandidate,
+    SupportsGatewaySelection,
+    UsernamePasswordCredentials,
+)
 from pyoverkiz.client import OverkizClient, OverkizClientSettings
 from pyoverkiz.const import USER_AGENT
 from pyoverkiz.enums import (
@@ -1231,8 +1235,6 @@ class TestOverkizClient:
         self, client: OverkizClient
     ) -> None:
         """discover_gateways delegates to a selection-capable strategy."""
-        from pyoverkiz.auth.base import GatewayCandidate, SupportsGatewaySelection
-
         fake_auth = MagicMock(spec=SupportsGatewaySelection)
         fake_auth.discover_gateways = AsyncMock(
             return_value=[GatewayCandidate(gateway_id="g1")]
@@ -1255,8 +1257,6 @@ class TestOverkizClient:
 
     def test_select_gateway_delegates_to_strategy(self, client: OverkizClient) -> None:
         """select_gateway forwards to a selection-capable strategy."""
-        from pyoverkiz.auth.base import SupportsGatewaySelection
-
         fake_auth = MagicMock(spec=SupportsGatewaySelection)
         client._auth = fake_auth
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -694,6 +694,24 @@ class TestOverkizClient:
         assert not resp.json.called
 
     @pytest.mark.asyncio
+    async def test_get_uses_auth_strategy_endpoint(self, client: OverkizClient) -> None:
+        """_get builds the URL from the auth strategy endpoint, not server_config."""
+        resp = MockResponse("{}")
+
+        with (
+            patch.object(
+                type(client._auth),
+                "endpoint",
+                property(lambda self: "https://swapped.test/api/"),
+            ),
+            patch.object(client, "_refresh_token_if_expired", new=AsyncMock()),
+            patch.object(aiohttp.ClientSession, "get", return_value=resp) as mock_get,
+        ):
+            await client._get("setup")
+
+        assert mock_get.call_args[0][0] == "https://swapped.test/api/setup"
+
+    @pytest.mark.asyncio
     async def test_post_returns_none_for_204_without_json_parse(
         self, client: OverkizClient
     ) -> None:
@@ -1227,48 +1245,6 @@ class TestUserAgent:
             credentials=UsernamePasswordCredentials("user", "pass"),
         )
         assert client.session.headers["User-Agent"] == USER_AGENT
-
-
-@pytest.mark.asyncio
-async def test_get_uses_auth_strategy_endpoint(monkeypatch):
-    """_get builds the URL from the auth strategy endpoint, not server_config."""
-    from unittest.mock import AsyncMock, MagicMock
-
-    from pyoverkiz.client import OverkizClient
-    from pyoverkiz.const import SUPPORTED_SERVERS
-    from pyoverkiz.enums import Server
-
-    client = OverkizClient(
-        server=SUPPORTED_SERVERS[Server.SOMFY_EUROPE],
-        credentials=UsernamePasswordCredentials("user", "pass"),
-    )
-
-    captured = {}
-
-    def fake_get(url, headers=None, ssl=None):
-        captured["url"] = url
-        resp = MagicMock()
-        resp.status = 200
-        resp.json = AsyncMock(return_value={})
-        resp.text = AsyncMock(return_value="{}")
-        ctx = MagicMock()
-        ctx.__aenter__ = AsyncMock(return_value=resp)
-        ctx.__aexit__ = AsyncMock(return_value=None)
-        return ctx
-
-    client.session.get = fake_get
-    client._refresh_token_if_expired = AsyncMock(return_value=None)
-    monkeypatch.setattr(
-        type(client._auth),
-        "endpoint",
-        property(lambda self: "https://swapped.test/api/"),
-    )
-    monkeypatch.setattr(type(client._auth), "auth_headers", lambda self, path=None: {})
-
-    await client._get("setup")
-
-    assert captured["url"] == "https://swapped.test/api/setup"
-    await client.close()
 
 
 class TestOverkizClientSettings:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
@@ -1225,6 +1225,44 @@ class TestOverkizClient:
             await local_client.schedule_persisted_action_group(
                 "00000000-0000-0000-0000-000000000000", 9999999999
             )
+
+    @pytest.mark.asyncio
+    async def test_discover_gateways_delegates_to_strategy(
+        self, client: OverkizClient
+    ) -> None:
+        """discover_gateways delegates to a selection-capable strategy."""
+        from pyoverkiz.auth.base import GatewayCandidate, SupportsGatewaySelection
+
+        fake_auth = MagicMock(spec=SupportsGatewaySelection)
+        fake_auth.discover_gateways = AsyncMock(
+            return_value=[GatewayCandidate(gateway_id="g1")]
+        )
+        client._auth = fake_auth
+
+        result = await client.discover_gateways()
+
+        assert result[0].gateway_id == "g1"
+        client._auth.discover_gateways.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_discover_gateways_raises_for_unsupported_strategy(
+        self, client: OverkizClient
+    ) -> None:
+        """discover_gateways raises TypeError when the strategy lacks the capability."""
+        # The default Somfy strategy does not implement SupportsGatewaySelection.
+        with pytest.raises(TypeError, match="does not support gateway selection"):
+            await client.discover_gateways()
+
+    def test_select_gateway_delegates_to_strategy(self, client: OverkizClient) -> None:
+        """select_gateway forwards to a selection-capable strategy."""
+        from pyoverkiz.auth.base import SupportsGatewaySelection
+
+        fake_auth = MagicMock(spec=SupportsGatewaySelection)
+        client._auth = fake_auth
+
+        client.select_gateway("g1")
+
+        fake_auth.select_gateway.assert_called_once_with("g1")
 
 
 class TestUserAgent:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1229,6 +1229,48 @@ class TestUserAgent:
         assert client.session.headers["User-Agent"] == USER_AGENT
 
 
+@pytest.mark.asyncio
+async def test_get_uses_auth_strategy_endpoint(monkeypatch):
+    """_get builds the URL from the auth strategy endpoint, not server_config."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from pyoverkiz.client import OverkizClient
+    from pyoverkiz.const import SUPPORTED_SERVERS
+    from pyoverkiz.enums import Server
+
+    client = OverkizClient(
+        server=SUPPORTED_SERVERS[Server.SOMFY_EUROPE],
+        credentials=UsernamePasswordCredentials("user", "pass"),
+    )
+
+    captured = {}
+
+    def fake_get(url, headers=None, ssl=None):
+        captured["url"] = url
+        resp = MagicMock()
+        resp.status = 200
+        resp.json = AsyncMock(return_value={})
+        resp.text = AsyncMock(return_value="{}")
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=resp)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        return ctx
+
+    client.session.get = fake_get
+    client._refresh_token_if_expired = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        type(client._auth),
+        "endpoint",
+        property(lambda self: "https://swapped.test/api/"),
+    )
+    monkeypatch.setattr(type(client._auth), "auth_headers", lambda self, path=None: {})
+
+    await client._get("setup")
+
+    assert captured["url"] == "https://swapped.test/api/setup"
+    await client.close()
+
+
 class TestOverkizClientSettings:
     """Tests for the OverkizClientSettings integration with OverkizClient."""
 


### PR DESCRIPTION
## Summary

Adds support for Rexel authentication in two modes, plus the gateway discovery/selection plumbing Rexel requires:

- **OAuth2 PKCE flow** — full interactive login for Rexel accounts (`pyoverkiz/pkce.py`, `RexelAuthStrategy`).
- **Externally-managed tokens** — `RexelTokenCredentials` + `RexelTokenAuthStrategy` let a host (e.g. Home Assistant) supply and refresh tokens it manages itself.
- **Gateway discovery & selection** — Rexel exposes multiple gateways via the enduser directory; the client now discovers candidates (`GatewayCandidate`, `SupportsGatewaySelection`), auto-selects a sole gateway at login, and injects the `gatewayId` header per request, guarding requests made before selection (`NoGatewaySelectedError`).

### Breaking change
- `auth_headers` is now **async** across all auth strategies. See `docs/migration-v2.md`.

### Docs
- Getting-started tab for the externally-managed token mode.
- Core-concepts note on the two Rexel auth modes.
- SDK reference renders the auth credentials module.
- Migration guide records the async `auth_headers` change.

## Test Plan
- [x] `pytest` — 488 passed (run in devcontainer)
- [ ] Verify interactive OAuth2 PKCE login against a real Rexel account
- [ ] Verify externally-managed token flow end-to-end from Home Assistant