### PR TITLE
Allow dict/list parameters in Command (#2089)

### DIFF
--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -358,7 +358,7 @@ class Command:
 
         if self.parameters is not None:
             payload["parameters"] = [
-                p if isinstance(p, (str, int, float, bool)) else str(p)
+                p if isinstance(p, (str, int, float, bool, dict, list)) else str(p)
                 for p in self.parameters
             ]
 

--- a/pyoverkiz/types.py
+++ b/pyoverkiz/types.py
@@ -11,7 +11,9 @@ from pyoverkiz.enums.command import OverkizCommandParam
 
 StateType = str | int | float | bool | dict[str, Any] | list[Any] | None
 
-CommandParameterValue = str | int | float | bool | OverkizCommandParam
+CommandParameterValue = (
+    str | int | float | bool | dict[str, Any] | list[Any] | OverkizCommandParam
+)
 
 
 def _parse_bool(value: str) -> bool:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -927,6 +927,31 @@ def test_command_to_payload_omits_none():
     assert payload == {"name": "close"}
 
 
+def test_command_to_payload_preserves_dict_parameter():
+    """Command.to_payload passes dict/list parameters through untouched.
+
+    Several Atlantic/Thermor commands (e.g. setAbsenceStartDate,
+    setCurrentOperatingMode) take a dict parameter that must reach the API as a
+    JSON object, not a stringified repr.
+    """
+    from pyoverkiz.models import Command
+
+    date = {
+        "year": 2026,
+        "month": 5,
+        "day": 28,
+        "hour": 12,
+        "minute": 0,
+        "second": 0,
+        "weekday": 3,
+    }
+    cmd = Command(name="setAbsenceStartDate", parameters=[date])
+
+    payload = cmd.to_payload()
+
+    assert payload["parameters"] == [date]
+
+
 def test_action_to_payload_and_parameters_conversion():
     """Action.to_payload converts nested Command enums to primitives."""
     from pyoverkiz.enums.command import OverkizCommand, OverkizCommandParam

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -952,6 +952,18 @@ def test_command_to_payload_preserves_dict_parameter():
     assert payload["parameters"] == [date]
 
 
+def test_command_to_payload_preserves_list_parameter():
+    """Command.to_payload passes a nested list parameter through untouched."""
+    from pyoverkiz.models import Command
+
+    schedule = [[0, 1, 2], [3, 4, 5]]
+    cmd = Command(name="setSchedule", parameters=[schedule])
+
+    payload = cmd.to_payload()
+
+    assert payload["parameters"] == [schedule]
+
+
 def test_action_to_payload_and_parameters_conversion():
     """Action.to_payload converts nested Command enums to primitives."""
     from pyoverkiz.enums.command import OverkizCommand, OverkizCommandParam


### PR DESCRIPTION
## Summary

Fixes #2089. `Command.parameters` could not be typed with `dict` elements, even though the Overkiz API accepts (and some commands require) a dict parameter. This forced consumers to `cast()` around the type, defeating the type checker for the exact case where it matters.

Examples of dict-valued command parameters:
- `setAbsenceStartDate` / `setAbsenceEndDate` — take a date dict (`{"year": ..., "month": ..., ...}`)
- `setCurrentOperatingMode` — takes `{"relaunch": "off", "absence": "on"}`

## Changes

- **Widen `CommandParameterValue`** in `pyoverkiz/types.py` to include `dict[str, Any]` and `list[Any]`, consistent with how `StateType` is already defined.
- **Fix `Command.to_payload`** in `pyoverkiz/models.py`. The serializer previously stringified anything that wasn't a `str`/`int`/`float`/`bool` (to handle `OverkizCommandParam` enums), so a dict parameter would have been sent as a Python `repr` string instead of a JSON object. Dicts and lists now pass through untouched.
- **Add a test** asserting a dict parameter survives `to_payload` round-trip.

## Notes

The issue's code snippet referenced a stale `class Command(dict)` shape; the type now lives in `CommandParameterValue` (`types.py`), which is where this patch widens it.

Once released and the requirement is bumped, the `cast()` workaround in the Home Assistant `overkiz` integration (water heater absence-date commands) can be removed.

## Test plan

- [x] `pytest tests/` — 457 passed
- [x] `mypy` clean on changed files
- [x] `ruff check` clean