### PR TITLE
fix(auth): add B2C policy to Rexel authorize URL

### DIFF
--- a/pyoverkiz/const.py
+++ b/pyoverkiz/const.py
@@ -32,7 +32,9 @@ REXEL_OAUTH_TENANT = (
     "https://consumerlogin.rexelservices.fr/670998c0-f737-4d75-a32f-ba9292755b70"
 )
 REXEL_OAUTH_POLICY = "b2c_1a_signinonlyhomeassistant"
-REXEL_OAUTH_AUTHORIZE_URL = f"{REXEL_OAUTH_TENANT}/oauth2/v2.0/authorize"
+REXEL_OAUTH_AUTHORIZE_URL = (
+    f"{REXEL_OAUTH_TENANT}/oauth2/v2.0/authorize?p={REXEL_OAUTH_POLICY}"
+)
 REXEL_OAUTH_TOKEN_URL = f"{REXEL_OAUTH_TENANT}/oauth2/v2.0/token?p={REXEL_OAUTH_POLICY}"
 REXEL_REQUIRED_CONSENT = "homeassistant"
 REXEL_GATEWAY_HEADER = "gatewayId"

--- a/pyoverkiz/utils.py
+++ b/pyoverkiz/utils.py
@@ -9,7 +9,6 @@ from pyoverkiz.const import (
     LOCAL_API_PATH,
     REXEL_OAUTH_AUTHORIZE_URL,
     REXEL_OAUTH_CLIENT_ID,
-    REXEL_OAUTH_POLICY,
     REXEL_OAUTH_REDIRECT_URI,
     REXEL_OAUTH_SCOPE,
 )
@@ -79,8 +78,8 @@ def build_rexel_authorization_url(
     Returns:
         Complete authorization URL
     """
+    # REXEL_OAUTH_AUTHORIZE_URL already carries the required B2C policy (?p=...).
     params = {
-        "p": REXEL_OAUTH_POLICY,
         "client_id": REXEL_OAUTH_CLIENT_ID,
         "response_type": "code",
         "redirect_uri": redirect_uri or REXEL_OAUTH_REDIRECT_URI,
@@ -94,4 +93,4 @@ def build_rexel_authorization_url(
         params["state"] = state
 
     query_string = urllib.parse.urlencode(params)
-    return f"{REXEL_OAUTH_AUTHORIZE_URL}?{query_string}"
+    return f"{REXEL_OAUTH_AUTHORIZE_URL}&{query_string}"


### PR DESCRIPTION
## Problem

Launching the Rexel OAuth2 authorize URL returns a generic IIS error instead of the login page:

> The resource you are looking for has been removed, had its name changed, or is temporarily unavailable.

Rexel logs in via an **Azure AD B2C** tenant using a custom policy (\`b2c_1a_signinonlyhomeassistant\`). On B2C the policy is **not** optional — the \`?p=<policy>\` query parameter selects which user flow runs. Without it, B2C can't resolve a policy and returns the error above.

## Root cause

\`REXEL_OAUTH_TOKEN_URL\` already carried \`?p={policy}\`, but \`REXEL_OAUTH_AUTHORIZE_URL\` did **not**:

\`\`\`python
REXEL_OAUTH_AUTHORIZE_URL = f"{REXEL_OAUTH_TENANT}/oauth2/v2.0/authorize"          # missing ?p=
REXEL_OAUTH_TOKEN_URL     = f"{REXEL_OAUTH_TENANT}/oauth2/v2.0/token?p={REXEL_OAUTH_POLICY}"
\`\`\`

Home Assistant's \`application_credentials\` \`AuthorizationServer\` consumes the bare \`REXEL_OAUTH_AUTHORIZE_URL\` constant directly and appends only the standard OAuth params (no \`p=\`), so the built authorize URL was missing the policy.

## Fix

- Add \`?p={policy}\` to \`REXEL_OAUTH_AUTHORIZE_URL\`, matching the token URL.
- Drop the now-redundant \`"p"\` entry from \`build_rexel_authorization_url()\` and append its params with \`&\` (the policy now lives in the constant), so that builder still emits exactly one \`?p=\`.

## Verification

\`\`\`
REXEL_OAUTH_AUTHORIZE_URL
  → .../oauth2/v2.0/authorize?p=b2c_1a_signinonlyhomeassistant

build_rexel_authorization_url("CHALLENGE", state="STATE")
  → .../authorize?p=b2c_1a_signinonlyhomeassistant&client_id=...&response_type=code&...&state=STATE
\`\`\`

- \`ruff check\` clean
- \`mypy\` clean (run in devcontainer)
- \`pytest tests/test_utils.py\` — 5 passed