### PR TITLE
ci(release): sync uv.lock when bumping package version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,13 @@ jobs:
             VERSION=${{ steps.retrieve-version.outputs.version }}
             uvx --from=toml-cli toml set --toml-path=pyproject.toml project.version $VERSION
 
+            # Keep uv.lock in sync with the bumped version of the pyoverkiz package itself
+            uv lock
+
             git config --local user.email "action@github.com"
             git config --local user.name "GitHub Action"
 
-            git add pyproject.toml
+            git add pyproject.toml uv.lock
             git commit -m "Bump package version to ${{ steps.retrieve-version.outputs.version }}."
 
             git tag -f -a ${{ github.event.release.tag_name }} -m "Release ${{ steps.retrieve-version.outputs.version }}."


### PR DESCRIPTION
## Problem

`uv.lock` embeds the version of the editable `pyoverkiz` package itself (`source = { editable = "." }`). The release workflow bumps the version in `pyproject.toml` and commits **only that file** — it never regenerates the lockfile.

As a result, `uv.lock` drifts one version behind on every release (e.g. the `2.0.0rc3` bump commit left `uv.lock` pinned at `rc2`). This surfaces as a spurious diff the next time any local `uv` command re-syncs the lockfile.

## Fix

Run `uv lock` after the version bump and stage `uv.lock` alongside `pyproject.toml` so the committed state stays internally consistent.

```diff
 uvx --from=toml-cli toml set --toml-path=pyproject.toml project.version $VERSION
+uv lock
 ...
-git add pyproject.toml
+git add pyproject.toml uv.lock
```