### PR TITLE
Add IP address, label and location states to obfuscation

### DIFF
--- a/pyoverkiz/obfuscate.py
+++ b/pyoverkiz/obfuscate.py
@@ -55,6 +55,10 @@ def _obfuscate_value(key: str, value: Any, mask_next_value: bool) -> tuple[Any, 
         "core:MacAddress",
         "core:SerialNumber",
         "core:DeviceSerialNumberState",
+        "core:IPAddressState",
+        "core:LabelState",
+        "core:LocationLatitudeState",
+        "core:LocationLongitudeState",
     ):
         mask_next_value = True
 

--- a/tests/test_obfuscate.py
+++ b/tests/test_obfuscate.py
@@ -123,6 +123,10 @@ class TestObfucscateSensitive:
             "core:MacAddress",
             "core:SerialNumber",
             "core:DeviceSerialNumberState",
+            "core:IPAddressState",
+            "core:LabelState",
+            "core:LocationLatitudeState",
+            "core:LocationLongitudeState",
         ],
     )
     def test_obfuscate_sensitive_states(self, state_name: str):


### PR DESCRIPTION
## Summary
Extend the obfuscation utility to redact the values of additional sensitive device states:

- `core:IPAddressState` (`CORE_IP_ADDRESS`)
- `core:LabelState` (`CORE_LABEL`)
- `core:LocationLatitudeState` (`CORE_LOCATION_LATITUDE`)
- `core:LocationLongitudeState` (`CORE_LOCATION_LONGITUDE`)

These states can expose a user's IP address, device label and geographic location, so their values should be masked alongside the other sensitive states already handled by `obfuscate_sensitive_data`.

## Test plan
- Added the four new state names to the `test_obfuscate_sensitive_states` parametrization.
- `pytest tests/test_obfuscate.py` → 30 passed.
- Full suite (`test_obfuscate.py`, `test_models.py`, `test_client.py`) → 325 passed.
- `ruff` and `mypy` (source) clean.