### PR TITLE
Add Rexel Energeasy Connect gateway type (19)

### DIFF
--- a/pyoverkiz/enums/gateway.py
+++ b/pyoverkiz/enums/gateway.py
@@ -13,7 +13,7 @@ class GatewayType(UnknownEnumMixin, IntEnum):
     VIRTUAL_KIZBOX = 0
     KIZBOX_V1 = 2
     TAHOMA = 15
-    ENERGEASY_CONNECT_V2 = 19  # Rexel Energeasy Connect (subType 0)
+    ENERGEASY_CONNECT_V2 = 19
     VERISURE_ALARM_SYSTEM = 20
     KIZBOX_MINI = 21
     HI_KUMO_ADAPTER = 22  # Hi Kumo Adapter SPX-WFG01 (constant added manually)

--- a/pyoverkiz/enums/gateway.py
+++ b/pyoverkiz/enums/gateway.py
@@ -13,6 +13,7 @@ class GatewayType(UnknownEnumMixin, IntEnum):
     VIRTUAL_KIZBOX = 0
     KIZBOX_V1 = 2
     TAHOMA = 15
+    ENERGEASY_CONNECT_V2 = 19  # Rexel Energeasy Connect (subType 0)
     VERISURE_ALARM_SYSTEM = 20
     KIZBOX_MINI = 21
     HI_KUMO_ADAPTER = 22  # Hi Kumo Adapter SPX-WFG01 (constant added manually)


### PR DESCRIPTION
## Summary
- Adds gateway type `19` to the `GatewayType` enum for the Rexel gateway.
- Named `ENERGEASY_CONNECT_V2` because `ENERGEASY_CONNECT = 57` already exists and `IntEnum` member names must be unique. Its `beautify_name` renders as "Energeasy Connect V2".

## Notes
- This gateway also reports `subType: 0`. No `GatewaySubType` member was added — value `0` already falls back to `UNKNOWN` via `UnknownEnumMixin`.

## Test plan
- `GatewayType(19)` → `ENERGEASY_CONNECT_V2` → "Energeasy Connect V2"
- `GatewayType(57)` → unchanged
- `uv run mypy pyoverkiz/enums/gateway.py` → no issues
- `uv run pytest -k "gateway or enum"` → 41 passed