### PR TITLE
fix(events): tolerate `deviceStates: null` in Event payloads

### DIFF
--- a/pyoverkiz/converter.py
+++ b/pyoverkiz/converter.py
@@ -14,6 +14,7 @@ from pyoverkiz._case import camelize_key
 from pyoverkiz.models import (
     CommandDefinition,
     CommandDefinitions,
+    EventState,
     State,
     StateDefinition,
     StateDefinitions,
@@ -80,9 +81,20 @@ def _make_converter() -> cattrs.Converter:
             return StateDefinitions()
         return StateDefinitions([c.structure(sd, StateDefinition) for sd in val])
 
+    # Event.device_states is a plain list[EventState], but the API may send an
+    # explicit `deviceStates: null`. cattrs' generic list hook iterates the value
+    # directly, so it raises on None; tolerate it the way 1.x did (None -> []).
+    def _structure_event_states(val: Any, _: type) -> list[EventState]:
+        if val is None:
+            return []
+        return [c.structure(s, EventState) for s in val]
+
     c.register_structure_hook(States, _structure_states)
     c.register_structure_hook(CommandDefinitions, _structure_command_definitions)
     c.register_structure_hook(StateDefinitions, _structure_state_definitions)
+    c.register_structure_hook_func(
+        lambda t: t == list[EventState], _structure_event_states
+    )
 
     # For all other attrs classes: lazily generate a hook that renames camelCase
     # API keys to snake_case on first use. This avoids manual dependency ordering.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1060,6 +1060,24 @@ class TestEvent:
         assert len(event.device_states) == 1
         assert isinstance(event.device_states[0], EventState)
 
+    def test_device_states_none_payload(self):
+        """An explicit ``deviceStates: null`` structures into an empty list."""
+        event = converter.structure(
+            {"name": "DeviceStateChangedEvent", "deviceStates": None},
+            Event,
+        )
+
+        assert event.device_states == []
+
+    def test_device_states_absent_payload(self):
+        """An omitted ``deviceStates`` key defaults to an empty list."""
+        event = converter.structure(
+            {"name": "DeviceStateChangedEvent"},
+            Event,
+        )
+
+        assert event.device_states == []
+
     def test_event_fixture_structures_all_events(self):
         """All events in the cloud fixture file structure without errors."""
         raw_events = json.loads((Path("tests/fixtures/event/events.json")).read_text())


### PR DESCRIPTION
Fixes #2103

## Problem

In 2.0.0rc3, `fetch_events()` raises `TypeError: 'NoneType' object is not iterable` when an API payload contains an explicit `deviceStates: null`. This regresses behavior that 1.x explicitly tolerated via its hand-written `__init__` (`[...] if device_states else []`).

## Root cause

The issue suggested patching the attrs `converter=` lambda (`for s in states or []`). I added a failing test and confirmed **that fix alone does not work** for the production path: cattrs structures `Event.device_states` (typed `list[EventState]`) using its own generic `structure_list` hook, which iterates the value *before* the attrs `converter=` lambda ever runs. The crash is in cattrs' `cols.py`, not the lambda.

| API payload | rc3 | this PR |
|---|---|---|
| `deviceStates` omitted | `[]` ✅ | `[]` ✅ |
| `deviceStates: null` | **TypeError** ❌ | `[]` ✅ |
| `deviceStates: [{...}]` | ✅ | ✅ |

## Fix

Register a cattrs structure hook for `list[EventState]` mapping `None → []`, mirroring the existing `_structure_states` pattern. This fixes the actual `fetch_events()` → `converter.structure(...)` path.

Restores the 1.x null-tolerance contract, so the temporary `device_states or []` workaround in the Home Assistant test helper can be removed.

> Note: this is a minimal, defensive fix. The issue's evidence that `deviceStates: null` actually occurs is circumstantial (the 1.x guard also covered the *omitted* case), but the hook costs nothing and removes a crash-on-plausible-payload risk without changing behavior for any valid payload.

## Tests

Added `test_device_states_none_payload` and `test_device_states_absent_payload` to `TestEvent` (TDD — confirmed the null case failed before the fix). Both exercise the `converter.structure` production path.

Full suite passes (503 tests), ruff + mypy clean.