### PR TITLE
perf(action-queue)!: lower default debounce delay from 0.5s to 0.1s

### DIFF
--- a/docs/action-queue.md
+++ b/docs/action-queue.md
@@ -99,8 +99,13 @@ print(exec_id1 == exec_id2)
 ```
 
 Defaults:
-- `delay=0.5`
+- `delay=0.1`
 - `max_actions=20`
+
+The `delay` is a debounce window: commands that arrive within it are merged into
+a single action group. Scenes and automations typically fan their commands out in
+the same event-loop tick, so they still collapse into one API call even with a
+short window — the window mainly adds latency to standalone interactive commands.
 
 ## Advanced settings
 

--- a/pyoverkiz/action_queue.py
+++ b/pyoverkiz/action_queue.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 class ActionQueueSettings:
     """Settings for configuring the action queue behavior."""
 
-    delay: float = 0.5
+    delay: float = 0.1
     max_actions: int = 20
 
     def validate(self) -> None:

--- a/tests/test_action_queue.py
+++ b/tests/test_action_queue.py
@@ -352,6 +352,13 @@ async def test_queued_execution_awaitable():
     await task
 
 
+def test_action_queue_settings_defaults():
+    """Default settings keep batching snappy while still merging same-tick calls."""
+    settings = ActionQueueSettings()
+    assert settings.delay == 0.1
+    assert settings.max_actions == 20
+
+
 @pytest.mark.asyncio
 async def test_action_queue_settings_validate():
     """Test that validate raises on invalid settings."""


### PR DESCRIPTION
## Summary

Lowers the default `ActionQueueSettings.delay` from **0.5s** to **0.1s**.

The queue's `delay` is a **debounce window**, not a "wait in case more commands are coming". The batching scenario it exists for — one scene fanning out to many devices — dispatches all its commands in the **same event-loop tick** (Home Assistant scenes/automations via `asyncio.gather`, the HomeKit bridge via back-to-back `async_create_task`). Those still collapse into a single action group regardless of window length. A long window therefore only adds latency to **standalone interactive commands**, where there is nothing to batch with.

## Measurements (from #2107, 50ms simulated RTT)

Single command — pure added latency:

| delay | API calls | max latency |
|---|---|---|
| 0.5s | 1 | 560 ms |
| **0.1s** | 1 | **159 ms** |
| 0.05s | 1 | 113 ms |

Same-tick 15-cover scene still batches into **1** API call at every window. 0.1s keeps a ~5ms cushion against dispatch jitter that 0.05s loses, and spends less exec rate-limit budget.

## Changes

- `pyoverkiz/action_queue.py`: default `delay` `0.5` → `0.1`.
- `docs/action-queue.md`: updated default + a note explaining the debounce semantics.
- `tests/test_action_queue.py`: added a test asserting the new default.

## Breaking changes

`ActionQueueSettings.delay` now defaults to `0.1`. Pass `ActionQueueSettings(delay=0.5)` to restore the old behavior.

## Open question (deferred)

The local API has no cloud exec rate limit, so it could justify an even shorter default. Left out of this PR to keep the change minimal — worth revisiting separately.

## Test plan

- [x] `ruff` / `mypy` / `ty` clean
- [x] Full suite green (502 passed)

Closes #2107