### PR TITLE
fix(deps): stop Dependabot ratcheting dependency floors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,11 @@ version: 2
 updates:
   - package-ecosystem: "uv"
     directory: "/"
+    # Only update uv.lock; never raise the abstract lower bounds in
+    # pyproject.toml. As a library we want a wide compatibility range for
+    # downstream consumers (e.g. Home Assistant), while still testing against
+    # the latest pinned versions via the lockfile.
+    versioning-strategy: lockfile-only
     schedule:
       interval: "weekly"
       time: "08:00"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
     { include = "pyoverkiz" }
 ]
 dependencies = [
-    "aiohttp>=3.14.0,<4.0.0",
+    "aiohttp>=3.10.3,<4.0.0",
     "backoff<3.0,>=1.10.0",
     "attrs>=22.2",
     "cattrs>=23.2",
@@ -22,7 +22,7 @@ dependencies = [
 
 [project.optional-dependencies]
 nexity = [
-    "boto3>=1.43.22,<2.0.0",
+    "boto3>=1.18.59,<2.0.0",
     "warrant-lite<2.0.0,>=1.0.4",
 ]
 docs = [

--- a/uv.lock
+++ b/uv.lock
@@ -1054,10 +1054,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = ">=3.14.0,<4.0.0" },
+    { name = "aiohttp", specifier = ">=3.10.3,<4.0.0" },
     { name = "attrs", specifier = ">=22.2" },
     { name = "backoff", specifier = ">=1.10.0,<3.0" },
-    { name = "boto3", marker = "extra == 'nexity'", specifier = ">=1.43.22,<2.0.0" },
+    { name = "boto3", marker = "extra == 'nexity'", specifier = ">=1.18.59,<2.0.0" },
     { name = "cattrs", specifier = ">=23.2" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0,<2.0" },
     { name = "mkdocs-autorefs", marker = "extra == 'docs'", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Problem

Dependabot's default `uv` versioning strategy raises the **lower bound** in `pyproject.toml` to the latest release on every bump. For a library this is the wrong behavior — it ratchets our floors upward with no compatibility benefit and breaks downstream consumers that pin older versions.

This surfaced with **aiohttp**: #2115 bumped the floor `>=3.10.3` → `>=3.14.0`, which conflicts with Home Assistant core's `aiohttp==3.13.5` pin, making pyoverkiz **uninstallable** there.

Auditing the rest of the deps, **boto3** had been ratcheted the same way across #2065 / #2080 / #2117 (`>=1.18.59` → `>=1.43.22`), though as an optional `nexity` dependency it had no visible impact. The remaining floors (`backoff`, `attrs`, `cattrs`, `warrant-lite`) were untouched by Dependabot and already have healthy wide ranges.

## Changes

- Restore `aiohttp` floor to `>=3.10.3` (was the floor before #2115)
- Restore `boto3` floor to `>=1.18.59` (was the floor before #2065)
- Set `versioning-strategy: lockfile-only` on the `uv` ecosystem in `.github/dependabot.yml`, so Dependabot updates `uv.lock` (keeping CI on the latest versions) without touching the abstract lower bounds in `pyproject.toml`

`uv.lock` still resolves both to their latest versions (aiohttp 3.14.0, boto3 1.43.22) — only the recorded specifiers change.

## Why this matters now

Without this, the next Dependabot run would re-raise the aiohttp floor straight back to 3.14 and reintroduce the HA core conflict. `lockfile-only` is the correct long-term policy for a library.