### PR TITLE
Fix OverkizCommandParam STANDARD/HISTORICAL/ERROR/UNHEALTHY casing regression

### DIFF
--- a/pyoverkiz/enums/command.py
+++ b/pyoverkiz/enums/command.py
@@ -1681,7 +1681,7 @@ class OverkizCommandParam(StrEnum):
     ENERGYHEAT = "energyheat"
     ENERGY_DEMAND_STATUS = "energyDemandStatus"
     ENVIRONMENT_PROTECTION = "environmentProtection"
-    ERROR = "Error"
+    ERROR = "error"
     ERROR_ABORT = "error-abort"
     ERROR_DEFAULT_INITIAL_CONDITION = "error-default-initial-condition"
     ERROR_INVALID_IMAGE = "error-invalid-image"
@@ -1771,7 +1771,7 @@ class OverkizCommandParam(StrEnum):
     HIGH = "high"
     HIGHEST = "highest"
     HIGH_DEMAND = "high demand"  # value with space
-    HISTORICAL = "Historical"
+    HISTORICAL = "historical"
     HI_FAN = "Hi FAN"  # value with space
     HOLIDAYS = "holidays"
     HOME = "home"
@@ -2048,7 +2048,7 @@ class OverkizCommandParam(StrEnum):
     SMOOTH = "smooth"
     SNAPSHOT = "snapshot"
     SOS = "sos"
-    STANDARD = "Standard"
+    STANDARD = "standard"
     STANDARD_SHUTTER = "standardShutter"
     STANDARD_SHUTTER_OPP = "standardShutterOpp"
     STANDBY = "standby"
@@ -2089,7 +2089,7 @@ class OverkizCommandParam(StrEnum):
     UNAVAILABLE = "unavailable"
     UNDEPLOYED = "undeployed"
     UNDETECTED = "undetected"
-    UNHEALTHY = "Unhealthy"
+    UNHEALTHY = "unhealthy"
     UNHEALTHY_ERROR = "Unhealthy, Error"  # value with space
     UNHEALTHY_FOR_SENSITIVE_GROUPS = "unhealthyForSensitiveGroups"
     UNINSTALLED = "uninstalled"

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -98,3 +98,7 @@ class TestOverkizCommandParamApiValues:
         assert OverkizCommandParam.OFF == "off"
         assert OverkizCommandParam.UNKNOWN == "unknown"
         assert OverkizCommandParam.BATTERY == "battery"
+        assert OverkizCommandParam.STANDARD == "standard"
+        assert OverkizCommandParam.HISTORICAL == "historical"
+        assert OverkizCommandParam.ERROR == "error"
+        assert OverkizCommandParam.UNHEALTHY == "unhealthy"


### PR DESCRIPTION
Follow-up to #2096.

## Problem

Four more `OverkizCommandParam` members were regressed from their lowercase API state values to capitalized variants in #2085 — the same bug class as `ON`/`OFF`/`UNKNOWN`/`BATTERY` (fixed in #2096):

| Member | Was | Now | Real lowercase source |
|--------|-----|-----|-----------------------|
| `STANDARD` | `"Standard"` | `"standard"` | `io:MemorizedSimpleVolumeState`, `io:VentilationConfigurationModeState`, `modbus:DHWModeState`, `modbus:YutakiDHWVirtualOperatingModeState` |
| `HISTORICAL` | `"Historical"` | `"historical"` | (Linky pair of `STANDARD`) |
| `ERROR` | `"Error"` | `"error"` | `core:UpdateStatusState` |
| `UNHEALTHY` | `"Unhealthy"` | `"unhealthy"` | `core:AirQualityIndexLevelState` |

The real Overkiz API returns these **state** values in lowercase, so every equality comparison against these members silently fails — breaking downstream consumers such as Home Assistant's `overkiz` integration (e.g. DHW/ventilation state maps keyed on `OverkizCommandParam.STANDARD`).

## Root cause

The capitalized values were harvested from *other* states that emit the same word in different casing (`zigbee:LinkyModeState` → `"Standard"`/`"Historical"`, `netatmo:HealthIndexState` → `"Error"`/`"Unhealthy"`). Both casings are real API values, but they collapse to one `SCREAMING_SNAKE` enum name. The generator's alphabetical sort (codepoint order, capitals first) let the capitalized catalog value claim the name and drop the lowercase value consumers depend on — exactly the mechanism described in #2096.

## Fix

1. Restore the four values to lowercase in `pyoverkiz/enums/command.py`. The generator's existing "preserve established value on a name collision" guard now pins them on regeneration.
2. Extend the #2093 regression test (`TestOverkizCommandParamApiValues`) to pin all four.

## Notes / follow-up

- `FAIR`/`POOR` were intentionally **left** as `"Fair"`/`"Poor"` — those casings are the only values `netatmo:HealthIndexState` emits; no lowercase variant exists in the API.
- The capitalized variants (`zigbee:LinkyModeState` `"Standard"`/`"Historical"`, `netatmo:HealthIndexState` `"Error"`/`"Unhealthy"`) are **dropped for now**. They're real state values the single-name enum structurally can't represent alongside the lowercase ones. Keeping both would require an explicit alias map in the generator (e.g. `STANDARD_LINKY = "Standard"`) plus a hard failure on unhandled collisions — tracked as a separate change.

## Verification

- `uv run utils/generate_enums.py` is idempotent — all four values stay lowercase after regeneration (`+0 new` params).
- `uv run pytest tests/test_enums.py` — 10 passed.