### PR TITLE
Route local API by api_type before server-specific strategies

### DIFF
--- a/pyoverkiz/auth/factory.py
+++ b/pyoverkiz/auth/factory.py
@@ -39,6 +39,20 @@ def build_auth_strategy(
     """Build the correct auth strategy for the given server and credentials."""
     server: Server | None = server_config.server
 
+    # Local API routing keys off api_type, not server, so a local config can
+    # carry any server identity (e.g. Server.REXEL) purely for labelling.
+    if server_config.api_type == APIType.LOCAL:
+        if isinstance(credentials, LocalTokenCredentials):
+            return LocalTokenAuthStrategy(
+                credentials, session, server_config, ssl_context
+            )
+        return BearerTokenAuthStrategy(
+            _ensure_credentials(credentials, TokenCredentials),
+            session,
+            server_config,
+            ssl_context,
+        )
+
     if server == Server.SOMFY_EUROPE:
         return SomfyAuthStrategy(
             _ensure_credentials(credentials, UsernamePasswordCredentials),
@@ -74,18 +88,6 @@ def build_auth_strategy(
             )
         return RexelAuthStrategy(
             _ensure_credentials(credentials, RexelOAuthCodeCredentials),
-            session,
-            server_config,
-            ssl_context,
-        )
-
-    if server_config.api_type == APIType.LOCAL:
-        if isinstance(credentials, LocalTokenCredentials):
-            return LocalTokenAuthStrategy(
-                credentials, session, server_config, ssl_context
-            )
-        return BearerTokenAuthStrategy(
-            _ensure_credentials(credentials, TokenCredentials),
             session,
             server_config,
             ssl_context,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -341,6 +341,33 @@ class TestAuthFactory:
         assert isinstance(strategy, LocalTokenAuthStrategy)
 
     @pytest.mark.asyncio
+    async def test_build_auth_strategy_local_token_with_cloud_server(self):
+        """A local config keeps local routing even when server is a cloud id.
+
+        Local API routing keys off api_type, so a config labelled with a
+        cloud-mapped server (e.g. Server.REXEL) must still select the local
+        token strategy rather than the Rexel OAuth strategy.
+        """
+        server_config = ServerConfig(
+            server=Server.REXEL,
+            name="Rexel Energeasy Connect (local)",
+            endpoint="https://gateway.local",
+            manufacturer="Rexel",
+            api_type=APIType.LOCAL,
+        )
+        credentials = LocalTokenCredentials("local_token")
+        session = AsyncMock(spec=ClientSession)
+
+        strategy = build_auth_strategy(
+            server_config=server_config,
+            credentials=credentials,
+            session=session,
+            ssl_context=True,
+        )
+
+        assert isinstance(strategy, LocalTokenAuthStrategy)
+
+    @pytest.mark.asyncio
     async def test_build_auth_strategy_local_bearer(self):
         """Test building local bearer token auth strategy."""
         server_config = ServerConfig(


### PR DESCRIPTION
## Summary
Move the `APIType.LOCAL` check to the top of `build_auth_strategy` so a local config can carry any `server` identity (e.g. `Server.REXEL`) purely for labelling, without misrouting to that server's cloud strategy.

## Why
Local configs are built via `create_local_server_config`. Previously, if a caller set `server=Server.REXEL` on a local config, the server-specific Rexel branch matched *before* the generic `api_type == APIType.LOCAL` branch and routed to the Rexel OAuth strategy — which rejects a local token with `TypeError`. The only `server` value that worked for local was one with no earlier branch (the `Server.SOMFY_DEVELOPER_MODE` default).

Routing on `api_type` first removes that coupling: `server`/`name`/`manufacturer` become free-form labels for local connections.

## Safety
Every server in `SUPPORTED_SERVERS` is `APIType.CLOUD`; the only source of `APIType.LOCAL` is `create_local_server_config` (or a hand-built `ServerConfig`). So moving the `LOCAL` check first cannot steal routing from any cloud server.

## Tests
- Adds `test_build_auth_strategy_local_token_with_cloud_server`: a local config with `server=Server.REXEL` must still select `LocalTokenAuthStrategy`.
- Full `tests/test_auth.py` suite passes (70 tests).