### PR TITLE
ci: strip Conventional-Commit prefix from changelog entries

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -41,6 +41,12 @@ autolabeler:
       - '/^dependabot\//'
     title:
       - '/^build\(deps\)/'
+# Strip the Conventional-Commit prefix from rendered entries: the prefix is needed
+# in the PR title for autolabeling, but is redundant once an entry is filed under its
+# section (e.g. "feat:" under New Features). "feat: Add X" renders as "Add X".
+replacers:
+  - search: '/\* (build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.+?\))?!?:\s*/g'
+    replace: '* '
 template: |
   ## What's changed
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  # Run on PRs so the autolabeler can apply Conventional-Commit labels from the title.
   pull_request:
     types: [opened, reopened, synchronize, edited]
 
@@ -13,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      # `write` is required for the autolabeler to add labels to PRs.
       pull-requests: write
     steps:
       - name: Update release draft

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,6 +242,10 @@ Always use full type annotations, generics, and other modern practices.
   | `build(deps):` / Dependabot | `dependencies` | :package: Dependencies |
   | `docs:` | `documentation` | :books: Documentation |
 
+- The prefix is stripped from the published changelog entry (it is redundant once the
+  entry sits under its section), so `feat: add X` renders as `Add X`. Keep the prefix
+  in the title regardless — it is what drives the labeling and sectioning.
+
 - Code quality work (refactors, performance, style, tests, CI, chores) all share the
   single `code-quality` bucket — pick the most accurate prefix; they land in the same
   section regardless.


### PR DESCRIPTION
## Problem

Changelog entries render the Conventional-Commit prefix that's already implied by the section — e.g. under :rocket: New Features:

> - **feat:** add core:IntrusionDetectedState for Somfy IntelliTAG air (#2142)

The `feat:` is redundant ("doubled") with the section heading.

## Change

The prefix can't simply be dropped from the PR title — it's the signal the autolabeler uses to sort entries into sections. Instead, strip it from the *rendered* entry via a Release Drafter `replacers` rule:

```yaml
replacers:
  - search: '/\* (build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.+?\))?!?:\s*/g'
    replace: '* '
```

Now `feat: add X` renders as `Add X` while the title keeps driving labeling/sectioning.

Also documents this in AGENTS.md (keep the prefix in titles; it's stripped on publish) and drops two now-obvious comments from the workflow.

Follow-up to #2143.