### PR TITLE
ci: Wire up Release Drafter autolabeler

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,14 +7,32 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, edited]
 
+permissions:
+  contents: read
+
 jobs:
+  # Draft the next release from merged PRs (main only).
   update_release_draft:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
+    steps:
+      - uses: release-drafter/release-drafter@ed4bc48ec97379be2258e7b7ac2624a3e26ab809 # v7.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Apply Conventional-Commit labels from the PR title (PRs only).
+  # The autolabeler is a separate sub-action; the main action above only drafts
+  # releases and does not apply labels.
+  autolabel:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
       pull-requests: write
     steps:
-      - name: Update release draft
-        uses: release-drafter/release-drafter@ed4bc48ec97379be2258e7b7ac2624a3e26ab809 # v7.4.0
+      - uses: release-drafter/release-drafter/autolabeler@ed4bc48ec97379be2258e7b7ac2624a3e26ab809 # v7.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The `autolabeler` rules added in #2143 were never actually executed. The main `release-drafter/release-drafter` action only **drafts releases** — it parses the full config (hence the deprecation warnings in its logs) but does **not** apply labels. Labeling is a *separate* sub-action: `release-drafter/release-drafter/autolabeler`.

Consequences observed:
- #2145 was opened with **no labels** at all.
- #2143 (`code-quality`) and #2144 (`ci`) were labeled **manually**, not by the action.
- No "add label" activity appears in any release-drafter run log.

Since the changelog draft groups by label, an unlabeled merged PR falls into the uncategorized bucket — the exact drop we set out to fix.

## Fix

- Add a dedicated `autolabel` job (PRs only) using the `release-drafter/release-drafter/autolabeler` sub-action, with `pull-requests: write`.
- Gate the existing `update_release_draft` job to `push` events, so each job only runs where it applies (no wasted draft run per PR).
- Pin both to the same SHA (v7.4.0).

Follow-up to #2143 / #2144.

## Verification

After merge I'll confirm a new PR gets labeled by `github-actions` (not manually). Also worth a separate cleanup: relabel #2144 `ci` -> `code-quality`, and deprecate the stale `ci` label (not part of the new scheme).