### PR TITLE
feat: harden HTTP resiliency with connection retries, request timeout, and docs

### DIFF
--- a/docs/resiliency.md
+++ b/docs/resiliency.md
@@ -29,9 +29,8 @@ Delays grow exponentially — the ceilings are 1s, 2s, 4s, 8s, … — but **ful
 is applied on top, so each actual wait is a random value between 0 and that ceiling
 (e.g. the first retry waits a random `0–1s`, the second a random `0–2s`). The
 randomization is deliberate: it spreads retries out so many clients do not all retry in
-lockstep ([AWS "Exponential Backoff and Jitter"](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)).
-Because of the jitter, the per-attempt delays are not a fixed sequence; the `max_time`
-budget is the upper bound that matters.
+lockstep. Because of the jitter, the per-attempt delays are not a fixed sequence; the
+`max_time` budget is the upper bound that matters.
 
 ### Connection errors fail fast
 

--- a/docs/resiliency.md
+++ b/docs/resiliency.md
@@ -23,6 +23,16 @@ so retries always give up rather than looping indefinitely.
 Everything else — `BadCredentialsError`, `TooManyRequestsError`, `MaintenanceError`,
 `UnsupportedOperationError`, and so on — is **not** retried and is raised directly.
 
+### Backoff timing
+
+Delays grow exponentially — the ceilings are 1s, 2s, 4s, 8s, … — but **full jitter**
+is applied on top, so each actual wait is a random value between 0 and that ceiling
+(e.g. the first retry waits a random `0–1s`, the second a random `0–2s`). The
+randomization is deliberate: it spreads retries out so many clients do not all retry in
+lockstep ([AWS "Exponential Backoff and Jitter"](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)).
+Because of the jitter, the per-attempt delays are not a fixed sequence; the `max_time`
+budget is the upper bound that matters.
+
 ### Connection errors fail fast
 
 Transient transport failures are retried quickly and then given up on (3 attempts

--- a/docs/resiliency.md
+++ b/docs/resiliency.md
@@ -1,0 +1,120 @@
+# Resiliency
+
+pyOverkiz retries transient failures automatically and raises typed exceptions for
+everything else. This page explains what the library handles for you, so you can
+decide what (if anything) to handle yourself.
+
+## What the library retries
+
+Every request is wrapped with [`backoff`](https://github.com/litl/backoff) decorators
+using exponential delays with full jitter. Each retry policy is capped by both a
+maximum number of attempts (`max_tries`) and a maximum wall-clock budget (`max_time`),
+so retries always give up rather than looping indefinitely.
+
+| Failure | Retried | Budget | On retry |
+| --- | --- | --- | --- |
+| Connection errors — `TimeoutError`, `ClientConnectorError`, `ServerDisconnectedError` | yes | 3 tries / ~30s | reopen the connection |
+| `NotAuthenticatedError` (session expired) | yes | 2 tries / ~60s | call `login()` |
+| `TooManyConcurrentRequestsError` | yes | 5 tries / ~120s | — |
+| `TooManyExecutionsError` | yes | 5 tries / ~300s | — |
+| `ExecutionQueueFullError` | yes | 5 tries / ~120s | — |
+| Event-listener errors — `InvalidEventListenerIdError`, `NoRegisteredEventListenerError` | yes (on `fetch_events`) | 2 tries / ~30s | re-register the listener |
+
+Everything else — `BadCredentialsError`, `TooManyRequestsError`, `MaintenanceError`,
+`UnsupportedOperationError`, and so on — is **not** retried and is raised directly.
+
+### Connection errors fail fast
+
+Transient transport failures are retried quickly and then given up on (3 attempts
+within roughly 30 seconds). This is deliberate: it is better to surface a failure to
+the caller than to keep a request hanging for minutes. For a polling loop such as
+`fetch_events()`, letting a call fail and retrying on the next poll tick is usually the
+right behaviour.
+
+A dropped keep-alive socket (`ServerDisconnectedError`) is treated as a connection
+blip and simply retried — it does **not** trigger a re-login. A genuine session expiry
+is reported by the server as a `Not authenticated` response, which raises
+`NotAuthenticatedError` and escalates to a re-login through the separate auth policy.
+
+!!! note "`max_time` does not interrupt a hung request"
+    The `max_time` budget only bounds the scheduling of retries *between* attempts; it
+    cannot cancel a single in-flight request. A request that hangs is bounded by the
+    session timeout (see below), which surfaces as a `TimeoutError` and is then retried.
+
+## Request timeout
+
+When pyOverkiz creates its own session, it applies a default per-request timeout
+(`total=15s`, `sock_connect=10s`). This is kept below the connection-retry budget so a
+hung socket fails fast and is retried, instead of blocking on aiohttp's 300-second
+default.
+
+If you pass your own `ClientSession`, **you own its timeout** — pyOverkiz does not
+override it. Configure one explicitly:
+
+```python
+from aiohttp import ClientSession, ClientTimeout
+
+from pyoverkiz.auth.credentials import UsernamePasswordCredentials
+from pyoverkiz.client import OverkizClient
+from pyoverkiz.enums import Server
+
+session = ClientSession(timeout=ClientTimeout(total=15, sock_connect=10))
+
+client = OverkizClient(
+    server=Server.SOMFY_EUROPE,
+    credentials=UsernamePasswordCredentials("you@example.com", "password"),
+    session=session,
+)
+```
+
+## What you should handle
+
+Because the library already retries transient failures, most consumers only need to
+handle the terminal cases:
+
+- **`BadCredentialsError`** — the credentials are wrong; retrying will not help. Prompt
+  for new credentials.
+- **`TooManyRequestsError`** — you are being rate limited. Reduce your polling
+  frequency. This is intentionally not retried so you do not make the situation worse.
+- **`MaintenanceError` / `ServiceUnavailableError`** — the backend is temporarily
+  unavailable. Back off and try again later.
+- **`NotAuthenticatedError`** — only reaches you if the automatic re-login also failed.
+  Call `login()` and retry.
+
+```python
+import asyncio
+
+from pyoverkiz.auth.credentials import UsernamePasswordCredentials
+from pyoverkiz.client import OverkizClient
+from pyoverkiz.enums import Server
+from pyoverkiz.exceptions import (
+    MaintenanceError,
+    NotAuthenticatedError,
+    TooManyRequestsError,
+)
+
+
+async def fetch_devices() -> None:
+    async with OverkizClient(
+        server=Server.SOMFY_EUROPE,
+        credentials=UsernamePasswordCredentials("you@example.com", "password"),
+    ) as client:
+        await client.login()
+        try:
+            print(await client.get_devices())
+        except NotAuthenticatedError:
+            await client.login()
+            print(await client.get_devices())
+        except TooManyRequestsError:
+            # Rate limited — slow down your polling.
+            await asyncio.sleep(60)
+        except MaintenanceError:
+            # Backend under maintenance — try again later.
+            pass
+
+
+asyncio.run(fetch_devices())
+```
+
+All exceptions derive from `BaseOverkizError`, so you can catch that as a catch-all for
+anything the library raises.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -82,9 +82,11 @@ asyncio.run(fetch_devices_with_retry())
 - Refresh setup with `get_setup()` and re-fetch devices.
 - Confirm you are using the correct gateway and server.
 
-## Timeouts
+## Timeouts and retries
 
-For long-running operations, prefer shorter request timeouts with retries rather than a single long timeout.
+The library retries transient connection and rate-limit failures automatically and
+applies a default request timeout. See [Resiliency](resiliency.md) for the full retry
+strategy and for configuring timeouts on a custom session.
 
 ## Logging
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
       - Device control: device-control.md
       - Action queue: action-queue.md
       - Event handling: event-handling.md
+      - Resiliency: resiliency.md
       - Troubleshooting: troubleshooting.md
       - Migrating from v1: migration-v2.md
   - Reference:

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -73,7 +73,6 @@ from pyoverkiz.serializers import prepare_payload
 
 _LOGGER = logging.getLogger(__name__)
 
-# Default per-request timeout for the client-owned session (see docs: Resiliency).
 DEFAULT_TIMEOUT = ClientTimeout(total=15, sock_connect=10)
 
 
@@ -92,7 +91,6 @@ async def refresh_listener(invocation: Details) -> None:
     await _get_client_from_invocation(invocation).register_event_listener()
 
 
-# Reusable backoff decorators (see docs: Resiliency for the full strategy).
 retry_on_auth_error = backoff.on_exception(
     backoff.expo,
     NotAuthenticatedError,
@@ -103,7 +101,6 @@ retry_on_auth_error = backoff.on_exception(
     logger=_LOGGER,
 )
 
-# Transient transport failures: retry fast (3 tries / ~30s), no relogin.
 retry_on_connection_failure = backoff.on_exception(
     backoff.expo,
     (TimeoutError, ClientConnectorError, ServerDisconnectedError),

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -17,6 +17,7 @@ from aiohttp import (
     ClientConnectorError,
     ClientResponse,
     ClientSession,
+    ClientTimeout,
     ServerDisconnectedError,
 )
 from backoff.types import Details
@@ -72,6 +73,9 @@ from pyoverkiz.serializers import prepare_payload
 
 _LOGGER = logging.getLogger(__name__)
 
+# Default per-request timeout for the client-owned session (see docs: Resiliency).
+DEFAULT_TIMEOUT = ClientTimeout(total=15, sock_connect=10)
+
 
 def _get_client_from_invocation(invocation: Details) -> OverkizClient:
     """Return the `OverkizClient` instance from a backoff invocation."""
@@ -88,20 +92,21 @@ async def refresh_listener(invocation: Details) -> None:
     await _get_client_from_invocation(invocation).register_event_listener()
 
 
-# Reusable backoff decorators with max_tries and max_time to cap total retry duration.
+# Reusable backoff decorators (see docs: Resiliency for the full strategy).
 retry_on_auth_error = backoff.on_exception(
     backoff.expo,
-    (NotAuthenticatedError, ServerDisconnectedError),
+    NotAuthenticatedError,
     max_tries=2,
-    max_time=60,  # safety net for hung requests
+    max_time=60,
     jitter=backoff.full_jitter,
     on_backoff=relogin,
     logger=_LOGGER,
 )
 
+# Transient transport failures: retry fast (3 tries / ~30s), no relogin.
 retry_on_connection_failure = backoff.on_exception(
     backoff.expo,
-    (TimeoutError, ClientConnectorError),
+    (TimeoutError, ClientConnectorError, ServerDisconnectedError),
     max_tries=3,
     max_time=30,
     jitter=backoff.full_jitter,
@@ -226,7 +231,9 @@ class OverkizClient:
         self.gateways: list[Gateway] = []
         self._event_listener_id: str | None = None
 
-        self.session = session or ClientSession(headers={"User-Agent": USER_AGENT})
+        self.session = session or ClientSession(
+            headers={"User-Agent": USER_AGENT}, timeout=DEFAULT_TIMEOUT
+        )
         self._ssl = verify_ssl
 
         if self.server_config.api_type == APIType.LOCAL and verify_ssl:

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -102,8 +102,8 @@ retry_on_auth_error = backoff.on_exception(
 retry_on_connection_failure = backoff.on_exception(
     backoff.expo,
     (TimeoutError, ClientConnectorError),
-    max_tries=5,
-    max_time=120,
+    max_tries=3,
+    max_time=30,
     jitter=backoff.full_jitter,
     logger=_LOGGER,
 )

--- a/pyoverkiz/client.py
+++ b/pyoverkiz/client.py
@@ -476,7 +476,6 @@ class OverkizClient:
     @retry_on_concurrent_requests
     @retry_on_auth_error
     @retry_on_listener_error
-    @retry_on_connection_failure
     async def fetch_events(self) -> list[Event]:
         """Fetch new events from a registered event listener. Fetched events are removed.
 
@@ -1021,6 +1020,7 @@ class OverkizClient:
         """
         await self._delete(f"setup/gateways/{gateway_id}/developerMode")
 
+    @retry_on_connection_failure
     async def _get(self, path: str) -> Any:
         """Make a GET request to the OverKiz API."""
         await self._refresh_token_if_expired()
@@ -1032,6 +1032,7 @@ class OverkizClient:
         ) as response:
             return await self._parse_response(response)
 
+    @retry_on_connection_failure
     async def _post(
         self,
         path: str,
@@ -1050,6 +1051,7 @@ class OverkizClient:
         ) as response:
             return await self._parse_response(response)
 
+    @retry_on_connection_failure
     async def _put(self, path: str, payload: dict[str, Any] | None = None) -> Any:
         """Make a PUT request to the OverKiz API."""
         await self._refresh_token_if_expired()
@@ -1062,6 +1064,7 @@ class OverkizClient:
         ) as response:
             return await self._parse_response(response)
 
+    @retry_on_connection_failure
     async def _delete(self, path: str) -> None:
         """Make a DELETE request to the OverKiz API."""
         await self._refresh_token_if_expired()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -72,12 +72,7 @@ class TestOverkizClient:
     async def test_backoff_retries_command_on_connection_failure(
         self, client: OverkizClient
     ) -> None:
-        """Ensure the command path retries transient connection failures.
-
-        Regression test for #2147: a transient ``TimeoutError`` raised on the
-        execute command path must be retried instead of propagating raw on the
-        first occurrence.
-        """
+        """Ensure the command path retries a transient connection failure."""
         resp = MockResponse(json.dumps({"execId": "exec-1"}))
 
         with (
@@ -100,11 +95,7 @@ class TestOverkizClient:
     async def test_backoff_gives_up_after_max_tries_on_connection_failure(
         self, client: OverkizClient
     ) -> None:
-        """Ensure connection failures are re-raised after max_tries attempts.
-
-        ``retry_on_connection_failure`` is capped at 3 attempts (1 initial + 2
-        retries); a persistent failure must surface rather than retry forever.
-        """
+        """Ensure a persistent connection failure is re-raised after 3 attempts."""
         with (
             patch("backoff._async.asyncio.sleep", new=AsyncMock()) as sleep_mock,
             patch.object(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -68,6 +68,58 @@ class TestOverkizClient:
             devices = await client.get_devices()
             assert len(devices) == 23
 
+    @pytest.mark.asyncio
+    async def test_backoff_retries_command_on_connection_failure(
+        self, client: OverkizClient
+    ) -> None:
+        """Ensure the command path retries transient connection failures.
+
+        Regression test for #2147: a transient ``TimeoutError`` raised on the
+        execute command path must be retried instead of propagating raw on the
+        first occurrence.
+        """
+        resp = MockResponse(json.dumps({"execId": "exec-1"}))
+
+        with (
+            patch("backoff._async.asyncio.sleep", new=AsyncMock()) as sleep_mock,
+            patch.object(
+                aiohttp.ClientSession,
+                "post",
+                side_effect=[TimeoutError("timed out"), resp],
+            ) as post_mock,
+        ):
+            exec_id = await client.execute_action_group(
+                actions=[Action(device_url="io://1234-5678-9012/12345678")],
+            )
+
+        assert exec_id == "exec-1"
+        assert post_mock.call_count == 2
+        assert sleep_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_backoff_retries_get_on_connection_failure(
+        self, client: OverkizClient
+    ) -> None:
+        """Ensure GET requests retry transient ``ClientConnectorError`` failures."""
+        resp = MockResponse(json.dumps({"protocolVersion": "1"}))
+        connection_error = aiohttp.ClientConnectorError(
+            connection_key=MagicMock(), os_error=OSError("unreachable")
+        )
+
+        with (
+            patch("backoff._async.asyncio.sleep", new=AsyncMock()) as sleep_mock,
+            patch.object(
+                aiohttp.ClientSession,
+                "get",
+                side_effect=[connection_error, resp],
+            ) as get_mock,
+        ):
+            result = await client.get_api_version()
+
+        assert result == "1"
+        assert get_mock.call_count == 2
+        assert sleep_mock.await_count == 1
+
     @pytest.mark.parametrize(
         ("fixture_name", "event_length"),
         [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -59,6 +59,19 @@ class TestOverkizClient:
         assert local_client.server_config.api_type == APIType.LOCAL
 
     @pytest.mark.asyncio
+    async def test_default_session_has_request_timeout(
+        self, client: OverkizClient
+    ) -> None:
+        """A client-owned session applies a default per-request timeout."""
+        from pyoverkiz.client import DEFAULT_TIMEOUT
+
+        assert client.session.timeout.total == DEFAULT_TIMEOUT.total
+        # Must stay below the connection-retry budget so a hung socket fails fast.
+        assert client.session.timeout.total is not None
+        assert client.session.timeout.total <= 30
+        await client.session.close()
+
+    @pytest.mark.asyncio
     async def test_get_devices_basic(self, client: OverkizClient):
         """Ensure the client can fetch and parse the basic devices fixture."""
         with (CURRENT_DIR / "devices.json").open(encoding="utf-8") as raw_devices:
@@ -109,6 +122,66 @@ class TestOverkizClient:
 
         assert get_mock.call_count == 3
         assert sleep_mock.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_backoff_retries_on_server_disconnected_without_relogin(
+        self, client: OverkizClient
+    ) -> None:
+        """A dropped keep-alive socket is retried as a connection blip, not a relogin."""
+        client.login = AsyncMock()
+        resp = MockResponse(json.dumps({"protocolVersion": "1"}))
+
+        with (
+            patch("backoff._async.asyncio.sleep", new=AsyncMock()) as sleep_mock,
+            patch.object(
+                aiohttp.ClientSession,
+                "get",
+                side_effect=[aiohttp.ServerDisconnectedError(), resp],
+            ) as get_mock,
+        ):
+            result = await client.get_api_version()
+
+        assert result == "1"
+        assert get_mock.call_count == 2
+        assert sleep_mock.await_count == 1
+        # A transport blip must not trigger a (heavy) relogin.
+        assert client.login.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_server_disconnected_escalates_to_relogin_when_auth_expired(
+        self, client: OverkizClient
+    ) -> None:
+        """If retrying a disconnect surfaces a real auth expiry, relogin still kicks in."""
+        client.login = AsyncMock()
+
+        with (
+            patch("backoff._async.asyncio.sleep", new=AsyncMock()) as sleep_mock,
+            patch.object(
+                aiohttp.ClientSession,
+                "get",
+                side_effect=[
+                    # Transport blip, retried by the connection decorator.
+                    aiohttp.ServerDisconnectedError(),
+                    # Retry reaches the server, which reports the session expired.
+                    MockResponse(
+                        json.dumps(
+                            {
+                                "errorCode": "RESOURCE_ACCESS_DENIED",
+                                "error": "Not authenticated",
+                            }
+                        ),
+                        status=401,
+                    ),
+                    # After relogin, the auth decorator retries and succeeds.
+                    MockResponse(json.dumps({"protocolVersion": "1"})),
+                ],
+            ),
+        ):
+            result = await client.get_api_version()
+
+        assert result == "1"
+        assert client.login.await_count == 1
+        assert sleep_mock.await_count >= 1
 
     @pytest.mark.parametrize(
         ("fixture_name", "event_length"),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -97,30 +97,6 @@ class TestOverkizClient:
         assert sleep_mock.await_count == 1
 
     @pytest.mark.asyncio
-    async def test_backoff_retries_get_on_connection_failure(
-        self, client: OverkizClient
-    ) -> None:
-        """Ensure GET requests retry transient ``ClientConnectorError`` failures."""
-        resp = MockResponse(json.dumps({"protocolVersion": "1"}))
-        connection_error = aiohttp.ClientConnectorError(
-            connection_key=MagicMock(), os_error=OSError("unreachable")
-        )
-
-        with (
-            patch("backoff._async.asyncio.sleep", new=AsyncMock()) as sleep_mock,
-            patch.object(
-                aiohttp.ClientSession,
-                "get",
-                side_effect=[connection_error, resp],
-            ) as get_mock,
-        ):
-            result = await client.get_api_version()
-
-        assert result == "1"
-        assert get_mock.call_count == 2
-        assert sleep_mock.await_count == 1
-
-    @pytest.mark.asyncio
     async def test_backoff_gives_up_after_max_tries_on_connection_failure(
         self, client: OverkizClient
     ) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -120,6 +120,29 @@ class TestOverkizClient:
         assert get_mock.call_count == 2
         assert sleep_mock.await_count == 1
 
+    @pytest.mark.asyncio
+    async def test_backoff_gives_up_after_max_tries_on_connection_failure(
+        self, client: OverkizClient
+    ) -> None:
+        """Ensure connection failures are re-raised after max_tries attempts.
+
+        ``retry_on_connection_failure`` is capped at 3 attempts (1 initial + 2
+        retries); a persistent failure must surface rather than retry forever.
+        """
+        with (
+            patch("backoff._async.asyncio.sleep", new=AsyncMock()) as sleep_mock,
+            patch.object(
+                aiohttp.ClientSession,
+                "get",
+                side_effect=TimeoutError("timed out"),
+            ) as get_mock,
+            pytest.raises(TimeoutError),
+        ):
+            await client.get_api_version()
+
+        assert get_mock.call_count == 3
+        assert sleep_mock.await_count == 2
+
     @pytest.mark.parametrize(
         ("fixture_name", "event_length"),
         [


### PR DESCRIPTION
## Summary

Fixes #2147.

Hardens the client's behaviour on transient network failures and documents the full resiliency strategy. Builds on the original connection-retry centralization with a request timeout, smarter `ServerDisconnectedError` handling, and user docs.

## Changes

### Centralize connection retry (original fix)

Previously only `fetch_events` was decorated with `@retry_on_connection_failure`, so a transient `TimeoutError` / `aiohttp.ClientConnectorError` raised from any other method — including the command path (`execute_action_group` -> `_execute_action_group_direct`) and all setup/state/refresh calls — propagated raw on the very first occurrence instead of being retried.

This surfaced in Home Assistant (home-assistant/core#173155): a `ConnectionTimeoutError` (subclass of the builtin `TimeoutError`) raised from a cover `close` command escaped as an unhandled traceback.

The retry is now centralized on the `_get`/`_post`/`_put`/`_delete` request helpers so every request gets uniform transient-connection retry, with connection retry sitting innermost (closest to the request). The budget is intentionally fail-fast: 3 tries within ~30s.

### Default request timeout

The client-owned session now applies a default per-request timeout (`total=15s`, `sock_connect=10s`), kept below the connection-retry budget so a hung socket fails fast as a `TimeoutError` and is retried, instead of blocking on aiohttp's 300s default. `max_time` only bounds the scheduling of retries between attempts; it cannot interrupt an in-flight request, so the timeout is what makes the fail-fast budget meaningful at runtime.

Callers passing their own `ClientSession` own its timeout; pyOverkiz does not override it.

### `ServerDisconnectedError` no longer forces a relogin

`ServerDisconnectedError` (a dropped keep-alive socket) was bucketed with `NotAuthenticatedError` and triggered a full `login()` + event-listener re-register on every occurrence. It is now treated as a transient transport failure and simply retried, with no relogin. A genuine session expiry is still reported by the server as a `Not authenticated` response, which raises `NotAuthenticatedError` and escalates to relogin via the separate auth policy.

### Docs

Adds `docs/resiliency.md` explaining what the library retries (with budgets and on-retry actions), the fail-fast rationale, exponential backoff with full jitter, request-timeout behaviour and how to configure a custom session, and which exceptions consumers should handle themselves. Linked from the nav and cross-referenced from `troubleshooting.md`.

## Tests

- `test_backoff_retries_command_on_connection_failure` / `test_backoff_gives_up_after_max_tries_on_connection_failure` — command/GET path connection retry and give-up.
- `test_backoff_retries_on_server_disconnected_without_relogin` — a disconnect is retried without calling `login()`.
- `test_server_disconnected_escalates_to_relogin_when_auth_expired` — a retry that surfaces a real auth expiry still triggers relogin.
- `test_default_session_has_request_timeout` — the client-owned session applies a default timeout within the retry budget.

## Verification

- 552 tests pass
- ruff clean
- mypy clean on `client.py`