### PR TITLE
Fix order-dependent masking leaking sensitive values

### DIFF
--- a/pyoverkiz/obfuscate.py
+++ b/pyoverkiz/obfuscate.py
@@ -5,6 +5,45 @@ from __future__ import annotations
 import re
 from typing import Any, cast
 
+# Keys whose value is an identifier (gateway id, device url, ...).
+_ID_KEYS = frozenset({"gatewayId", "id", "deviceURL"})
+
+# Keys whose value is free text / location data to fully mask.
+_STRING_KEYS = frozenset(
+    {
+        "label",
+        "city",
+        "country",
+        "postalCode",
+        "addressLine1",
+        "addressLine2",
+        "longitude",
+        "latitude",
+    }
+)
+
+# Overkiz attributes/states are {"name": ..., "value": ...} dicts. When "name"
+# is one of these, the sibling "value" holds PII and must be masked.
+_SENSITIVE_STATE_NAMES = frozenset(
+    {
+        "core:NameState",
+        "homekit:SetupCode",
+        "homekit:SetupPayload",
+        "core:SSIDState",
+        "core:NetworkMacState",
+        "internal:CurrentInfraConfigState",
+        "core:LocalIPv4AddressState",
+        "core:IPAddress",
+        "core:MacAddress",
+        "core:SerialNumber",
+        "core:DeviceSerialNumberState",
+        "core:IPAddressState",
+        "core:LabelState",
+        "core:LocationLatitudeState",
+        "core:LocationLongitudeState",
+    }
+)
+
 
 def obfuscate_id(value: str | None) -> str:
     """Mask id."""
@@ -22,57 +61,6 @@ def obfuscate_string(value: str) -> str:
     return re.sub(r"[\w.-]+", "*", str(value), flags=re.UNICODE)
 
 
-def _obfuscate_value(key: str, value: Any, mask_next_value: bool) -> tuple[Any, bool]:
-    """Return (obfuscated_value, mask_next_value) for a single key/value pair."""
-    result = value
-
-    if key in {"gatewayId", "id", "deviceURL"}:
-        result = obfuscate_id(value)
-    elif key in {
-        "label",
-        "city",
-        "country",
-        "postalCode",
-        "addressLine1",
-        "addressLine2",
-        "longitude",
-        "latitude",
-    }:
-        result = obfuscate_string(value)
-    elif mask_next_value and key == "value":
-        result = obfuscate_string(value)
-        return result, False
-
-    if result in (
-        "core:NameState",
-        "homekit:SetupCode",
-        "homekit:SetupPayload",
-        "core:SSIDState",
-        "core:NetworkMacState",
-        "internal:CurrentInfraConfigState",
-        "core:LocalIPv4AddressState",
-        "core:IPAddress",
-        "core:MacAddress",
-        "core:SerialNumber",
-        "core:DeviceSerialNumberState",
-        "core:IPAddressState",
-        "core:LabelState",
-        "core:LocationLatitudeState",
-        "core:LocationLongitudeState",
-    ):
-        mask_next_value = True
-
-    if isinstance(result, dict):
-        result = obfuscate_sensitive_data(result)
-    elif isinstance(result, list):
-        result = [
-            obfuscate_sensitive_data(item) if isinstance(item, dict) else item
-            for item in result
-        ]
-
-    return result, mask_next_value
-
-
 def obfuscate_sensitive_data(
     data: dict[str, Any] | list[dict[str, Any]],
 ) -> dict[str, Any] | list[dict[str, Any]]:
@@ -82,11 +70,24 @@ def obfuscate_sensitive_data(
             list[dict[str, Any]], [obfuscate_sensitive_data(item) for item in data]
         )
 
-    result: dict[str, Any] = {}
-    mask_next_value = False
+    # Decide up front whether this dict's "value" is sensitive, so masking does
+    # not depend on "name" appearing before "value" in the key iteration order.
+    mask_value = data.get("name") in _SENSITIVE_STATE_NAMES
 
+    result: dict[str, Any] = {}
     for key, value in data.items():
-        obfuscated, mask_next_value = _obfuscate_value(key, value, mask_next_value)
-        result[key] = obfuscated
+        if key in _ID_KEYS:
+            result[key] = obfuscate_id(value)
+        elif key in _STRING_KEYS or (key == "value" and mask_value):
+            result[key] = obfuscate_string(value)
+        elif isinstance(value, dict):
+            result[key] = obfuscate_sensitive_data(value)
+        elif isinstance(value, list):
+            result[key] = [
+                obfuscate_sensitive_data(item) if isinstance(item, dict) else item
+                for item in value
+            ]
+        else:
+            result[key] = value
 
     return result

--- a/tests/test_obfuscate.py
+++ b/tests/test_obfuscate.py
@@ -142,3 +142,18 @@ class TestObfucscateSensitive:
         result = obfuscate_sensitive_data(data)
         assert "Séjour" not in result["label"]
         assert "é" not in result["label"]
+
+    @pytest.mark.parametrize(
+        "state_name",
+        ["core:SerialNumber", "core:NameState"],
+    )
+    def test_obfuscate_sensitive_value_before_name(self, state_name: str):
+        """Value is redacted even when it precedes name in key order.
+
+        Some hubs return attributes/states as {"value", "type", "name"}, so
+        redaction must not depend on "name" being seen before "value".
+        """
+        data = {"value": "34-7E-5C-FA-A2-86:9", "type": 3, "name": state_name}
+        result = obfuscate_sensitive_data(data)
+        assert result["name"] == state_name
+        assert result["value"] != "34-7E-5C-FA-A2-86:9"


### PR DESCRIPTION
## Summary

`obfuscate_sensitive_data` masked attribute/state values by setting a "mask the next value" flag when it encountered a sensitive `name` key — assuming `name` always appears **before** its sibling `value` in iteration order.

Some hubs return these dicts in `{value, type, name}` order, so `value` was already emitted before the flag was set, and the sensitive value leaked **unmasked** into diagnostics.

Observed in a real diagnostics upload (see home-assistant/core#175618):
- `core:SerialNumber` — Sonos MAC addresses
- `core:NameState` — room / device names (PII)

## Fix

Decide up front whether a dict's `value` is sensitive from its `name`, then mask regardless of key order. Also hoisted the key sets to module-level frozensets and removed the now-unneeded `mask_next_value` threading.

## Tests

- New regression test covering value-before-name ordering (`core:SerialNumber`, `core:NameState`).
- All existing obfuscation tests still pass.
