### PR TITLE
feat: raise NoOverkizUserError for RESOURCE_ACCESS_DENIED "No such user account"

### DIFF
--- a/pyoverkiz/exceptions.py
+++ b/pyoverkiz/exceptions.py
@@ -128,6 +128,15 @@ class ApplicationNotAllowedError(ResourceAccessDeniedError):
     """Raised when the setup cannot be accessed through the application."""
 
 
+class NoOverkizUserError(ResourceAccessDeniedError):
+    """Raised when the account authenticated but has no Overkiz user on this server.
+
+    Login succeeds, but the token is not bound to an Overkiz user on this
+    endpoint. Seen for Somfy accounts that need the site-scoped multi-account
+    flow rather than the classic single-endpoint login.
+    """
+
+
 # Nexity
 class NexityBadCredentialsError(BadCredentialsError):
     """Raised when invalid credentials are provided to Nexity authentication API."""

--- a/pyoverkiz/response_handler.py
+++ b/pyoverkiz/response_handler.py
@@ -21,6 +21,7 @@ from pyoverkiz.exceptions import (
     MaintenanceError,
     MissingAPIKeyError,
     MissingAuthorizationTokenError,
+    NoOverkizUserError,
     NoRegisteredEventListenerError,
     NoSuchActionGroupError,
     NoSuchDeviceError,
@@ -61,6 +62,7 @@ _ERROR_CODE_MESSAGE_MAP: list[tuple[str, str | None, type[BaseOverkizError]]] = 
     ("AUTHENTICATION_ERROR", "API key is required", MissingAPIKeyError),
     ("AUTHENTICATION_ERROR", "No such user account", UnknownUserError),
     ("RESOURCE_ACCESS_DENIED", "Not authenticated", NotAuthenticatedError),
+    ("RESOURCE_ACCESS_DENIED", "No such user account", NoOverkizUserError),
     (
         "RESOURCE_ACCESS_DENIED",
         "Missing authorization token",

--- a/tests/fixtures/exceptions/cloud/no-overkiz-user.json
+++ b/tests/fixtures/exceptions/cloud/no-overkiz-user.json
@@ -1,0 +1,4 @@
+{
+    "errorCode": "RESOURCE_ACCESS_DENIED",
+    "error": "No such user account : user@example.tld"
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -631,6 +631,11 @@ class TestOverkizClient:
                 400,
             ),
             (
+                "cloud/no-overkiz-user.json",
+                exceptions.NoOverkizUserError,
+                403,
+            ),
+            (
                 "cloud/no-such-command.json",
                 exceptions.InvalidCommandError,
                 400,


### PR DESCRIPTION
## Summary

A valid Somfy account can authenticate via OAuth yet be rejected on the **first authenticated Overkiz call** (e.g. `POST events/register` during `login()`) with:

```json
HTTP 403
{ "errorCode": "RESOURCE_ACCESS_DENIED", "error": "No such user account : <email>" }
```

This happens because the plain SSO token is not bound to an Overkiz user on the classic single-endpoint host — these accounts need the site-scoped multi-account flow. Previously this fell through to a bare `ResourceAccessDeniedError`, which downstream (Home Assistant) surfaces as a generic "unknown error" + logged stack trace.

## Change

- New `NoOverkizUserError(ResourceAccessDeniedError)` exception.
- Mapped in the primary dispatch **only under `RESOURCE_ACCESS_DENIED`**, so the existing `AUTHENTICATION_ERROR` + "No such user account" → `UnknownUserError` login path (unsupported-hardware / Somfy Protect) is untouched.
- Test + fixture built from the real captured 403 response (email redacted).

## Why not `UnknownUserError`?

`UnknownUserError` means *unsupported hardware* (Somfy Protect / no supported devices). These multi-account Somfy accounts **do** have serviceable devices — they just require the site-scoped flow. Reusing `UnknownUserError` would tell users their hardware is unsupported and steer them away from the flow that actually works.

## Follow-up (not in this PR)

Home Assistant's config flow can catch `NoOverkizUserError` on the classic `Server.SOMFY_EUROPE` path to point users at the multi-account login. That belongs with the Somfy multi-account work.