### PR TITLE
Fix OverkizCommandParam FURTHER_NOTICE/NEXT_MODE casing regression

### DIFF
--- a/pyoverkiz/enums/command.py
+++ b/pyoverkiz/enums/command.py
@@ -1739,7 +1739,7 @@ class OverkizCommandParam(StrEnum):
     FULL_CLOSED = "full_closed"
     FULL_OPEN = "full_open"
     FURNACE = "furnace"
-    FURTHER_NOTICE = "furtherNotice"
+    FURTHER_NOTICE = "further_notice"
     GAS_METER = "Gas meter"  # value with space
     GEOFENCING_MODE = "geofencingMode"
     GOOD = "good"
@@ -1888,7 +1888,7 @@ class OverkizCommandParam(StrEnum):
     NAPLUG = "NAPlug"
     NATHERM_1 = "NATherm1"
     NETWORK_ERROR = "networkError"
-    NEXT_MODE = "nextMode"
+    NEXT_MODE = "next_mode"
     NL = "nl"
     NMG = "NMG"
     NMH = "NMH"


### PR DESCRIPTION
Fixes #2180.

Same casing-regression bug class as #2093/#2096 and #2126, this time for the `setDerogation` params.

## Problem

Two `OverkizCommandParam` members were regressed from their snake_case API values to camelCase during the 2.0 enum regeneration:

| Member | Was | Now (regressed) |
|--------|-----|-----------------|
| `FURTHER_NOTICE` | `"further_notice"` | `"furtherNotice"` |
| `NEXT_MODE` | `"next_mode"` | `"nextMode"` |

These are `setDerogation` command parameters. The real API expects the snake_case form — the server rejects the camelCase value with `INCOMPATIBLE_VALUE`:

```
setDerogation() : Invalid value for command parameter p2 : expected multi-type value,
one of [string value (further_notice, next_mode) or integer value >= 0]
but got furtherNotice (String)
```

The reported `io:DerogationTypeState` / `somfythermostat:DerogationTypeState` value is likewise snake_case (`further_notice`). Only the state *definition* `values` array advertises the camelCase form, which is what the generator picked up.

## Impact

Breaks `setDerogation` for every consumer, including Home Assistant `overkiz` climate entities (`SomfyThermostat`, `ValveHeatingTemperatureInterface`) — setting temperature/preset fails.

## Fix

Corrected the two values in `pyoverkiz/enums/command.py`. The generator's existing casing-clobber guard keeps regeneration idempotent: the corrected values now win the enum-name collision, so the harvested camelCase catalog values only map to the same names and are dropped.

## Verification

- Enum values now return `further_notice` / `next_mode`.
- Full test suite: 556 passed.
- Re-ran `utils/generate_enums.py` to confirm idempotency (`[+0 new]` params; corrected values preserved).