### PR TITLE
build(deps): bump github/codeql-action from 4.36.3 to 4.37.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,12 +31,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Bumps `github/codeql-action` (both `init` and `analyze`) from 4.36.3 to 4.37.0.

Both actions are pinned to the same commit SHA in `.github/workflows/codeql.yml`, so they must be bumped together in a single PR. Dependabot split this into two separate PRs (#2184 for `init`, #2183 for `analyze`) which cannot be merged independently without leaving the two on mismatched SHAs.

SHA `99df26d4f13ea111d4ec1a7dddef6063f76b97e9` = v4.37.0.

Closes #2184
Closes #2183