### PR TITLE
build(deps): group codeql-action updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,12 @@ updates:
       interval: "weekly"
       time: "08:00"
     open-pull-requests-limit: 10
+    groups:
+      # init and analyze are separate action paths but the same repo pinned to
+      # one SHA, so they must bump together in a single PR.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: "devcontainers"
     directory: "/"


### PR DESCRIPTION
Dependabot treats `github/codeql-action/init` and `github/codeql-action/analyze` as separate dependencies (different action paths), so it opens one PR per path — even though both are the same repo pinned to a single SHA in `.github/workflows/codeql.yml`. Merging them independently would leave the two on mismatched SHAs (see #2190, which combined #2184 + #2183 by hand).

This adds a Dependabot `group` so future `github/codeql-action*` bumps land in a single PR automatically.