### PR TITLE
feat: add typed SupportedAlias parsing and per-type resolution

### DIFF
--- a/docs/device-control.md
+++ b/docs/device-control.md
@@ -141,6 +141,27 @@ if cmd_def:
     print(f"Number of parameters: {cmd_def.nparams}")
 ```
 
+#### Resolve supported aliases
+
+Devices that support `goToAlias` advertise their alias slots through the
+`core:SupportedAliases` attribute. A device can list several ids for the same
+type (e.g. six `favorite1` slots), each covering a different subset of features.
+The official app shows a single control per type and targets the most featured
+id, which `get_most_featured_aliases()` reproduces:
+
+```python
+devices = await client.get_devices()
+device = devices[0]
+
+# All alias slots exactly as reported by the API
+for alias in device.get_supported_aliases():
+    print(f"{alias.type} (id {alias.id}): {alias.features}")
+
+# One alias per type, ready to use as a goToAlias parameter
+for alias_type, alias in device.get_most_featured_aliases().items():
+    print(f"{alias_type} -> goToAlias {alias.id}")
+```
+
 #### Access device identifier
 
 Device URLs are automatically parsed into structured identifier components for easier access:

--- a/docs/device-control.md
+++ b/docs/device-control.md
@@ -146,8 +146,7 @@ if cmd_def:
 Devices that support `goToAlias` advertise their alias slots through the
 `core:SupportedAliases` attribute. A device can list several ids for the same
 type (e.g. six `favorite1` slots), each covering a different subset of features.
-The official app shows a single control per type and targets the most featured
-id, which `get_most_featured_aliases()` reproduces:
+`get_most_featured_aliases()` returns the alias with the most features for each type:
 
 ```python
 devices = await client.get_devices()

--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -526,12 +526,7 @@ class Device:
         ]
 
     def get_most_featured_aliases(self) -> dict[str, SupportedAlias]:
-        """Return the alias to use per type, mirroring how the Somfy app resolves them.
-
-        A device can advertise several ids for the same type, each covering a
-        different subset of features. The app shows a single control per type and
-        targets the most featured id, preferring the earliest one on a tie.
-        """
+        """Return the alias with the most features for each type."""
         most_featured: dict[str, SupportedAlias] = {}
 
         for alias in self.get_supported_aliases():

--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -443,6 +443,15 @@ class DeviceIdentifier:
 
 
 @define(kw_only=True)
+class SupportedAlias:
+    """An alias slot advertised by a device through core:SupportedAliases."""
+
+    id: str
+    type: str
+    features: list[str] = field(factory=list)
+
+
+@define(kw_only=True)
 class Device:
     """Representation of a device in the setup including parsed fields and states."""
 
@@ -499,6 +508,39 @@ class Device:
     ) -> CommandDefinition | None:
         """Return the CommandDefinition for a command, or None if unavailable."""
         return self.definition.commands.get(str(command))
+
+    def get_supported_aliases(self) -> list[SupportedAlias]:
+        """Return the alias slots from core:SupportedAliases, empty when absent."""
+        raw_aliases = self.attributes.get_value(OverkizAttribute.CORE_SUPPORTED_ALIASES)
+
+        if not isinstance(raw_aliases, list):
+            return []
+
+        return [
+            SupportedAlias(
+                # The API reports ids as either a string or an integer
+                id=str(alias["id"]),
+                type=alias["type"],
+                features=list(alias.get("features", [])),
+            )
+            for alias in raw_aliases
+        ]
+
+    def get_most_featured_aliases(self) -> dict[str, SupportedAlias]:
+        """Return the alias to use per type, mirroring how the Somfy app resolves them.
+
+        A device can advertise several ids for the same type, each covering a
+        different subset of features. The app shows a single control per type and
+        targets the most featured id, preferring the earliest one on a tie.
+        """
+        most_featured: dict[str, SupportedAlias] = {}
+
+        for alias in self.get_supported_aliases():
+            current = most_featured.get(alias.type)
+            if current is None or len(alias.features) > len(current.features):
+                most_featured[alias.type] = alias
+
+        return most_featured
 
 
 # ---------------------------------------------------------------------------

--- a/pyoverkiz/models.py
+++ b/pyoverkiz/models.py
@@ -518,7 +518,6 @@ class Device:
 
         return [
             SupportedAlias(
-                # The API reports ids as either a string or an integer
                 id=str(alias["id"]),
                 type=alias["type"],
                 features=list(alias.get("features", [])),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1660,7 +1660,9 @@ class TestSupportedAliases:
     """Tests for parsing and resolving the core:SupportedAliases attribute."""
 
     @staticmethod
-    def _device_with_aliases(value: list[dict] | None) -> Device:
+    def _device_with_aliases(
+        value: list[dict[str, str | int | list[str]]] | None,
+    ) -> Device:
         """Create a Device exposing core:SupportedAliases with the given raw value."""
         attributes = (
             [{"name": "core:SupportedAliases", "type": 10, "value": value}]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,6 +51,7 @@ from pyoverkiz.models import (
     StateDefinition,
     StateDefinitions,
     States,
+    SupportedAlias,
     ZoneCreatedEvent,
     ZoneDeletedEvent,
     ZoneUpdatedEvent,
@@ -1653,3 +1654,93 @@ def test_get_command_definition_empty_definition():
         type=ProductType.ACTUATOR,
     )
     assert device.get_command_definition("open") is None
+
+
+class TestSupportedAliases:
+    """Tests for parsing and resolving the core:SupportedAliases attribute."""
+
+    @staticmethod
+    def _device_with_aliases(value: list[dict] | None) -> Device:
+        """Create a Device exposing core:SupportedAliases with the given raw value."""
+        attributes = (
+            [{"name": "core:SupportedAliases", "type": 10, "value": value}]
+            if value is not None
+            else []
+        )
+        return _make_device({**RAW_DEVICES, "attributes": attributes})
+
+    def test_returns_empty_list_when_attribute_is_absent(self):
+        """Devices without the attribute report no aliases instead of raising."""
+        assert self._device_with_aliases(None).get_supported_aliases() == []
+        assert self._device_with_aliases(None).get_most_featured_aliases() == {}
+
+    def test_parses_raw_entries_into_typed_aliases(self):
+        """Each raw entry becomes a SupportedAlias with id, type and features."""
+        device = self._device_with_aliases(
+            [{"id": "55299", "type": "ventilation", "features": ["openClose"]}]
+        )
+
+        assert device.get_supported_aliases() == [
+            SupportedAlias(id="55299", type="ventilation", features=["openClose"])
+        ]
+
+    def test_normalizes_integer_ids_to_string(self):
+        """The API is inconsistent about id typing, so ids are always strings."""
+        device = self._device_with_aliases([{"id": 1, "type": "favorite1"}])
+
+        alias = device.get_supported_aliases()[0]
+        assert alias.id == "1"
+        assert alias.features == []
+
+    def test_resolves_most_featured_alias_per_type(self):
+        """A duplicated type collapses to the entry advertising the most features."""
+        device = self._device_with_aliases(
+            [
+                {"id": "1", "type": "favorite1", "features": ["openClosePosition"]},
+                {
+                    "id": "3",
+                    "type": "favorite1",
+                    "features": ["openClosePosition", "tiltPosition"],
+                },
+                {"id": "2", "type": "favorite1", "features": ["tiltPosition"]},
+            ]
+        )
+
+        assert device.get_most_featured_aliases() == {
+            "favorite1": SupportedAlias(
+                id="3",
+                type="favorite1",
+                features=["openClosePosition", "tiltPosition"],
+            )
+        }
+
+    def test_breaks_ties_on_array_order(self):
+        """The Somfy app picks the first of equally featured entries, not the lowest id."""
+        device = self._device_with_aliases(
+            [
+                {"id": "6", "type": "favorite1", "features": ["tilt", "openClose"]},
+                {"id": "4", "type": "favorite1", "features": ["tilt", "openClose"]},
+                {"id": "1", "type": "favorite1", "features": ["openClose"]},
+            ]
+        )
+
+        assert device.get_most_featured_aliases()["favorite1"].id == "6"
+
+    def test_keeps_one_alias_for_every_type(self):
+        """Distinct types each resolve independently."""
+        device = self._device_with_aliases(
+            [
+                {"id": "1", "type": "favorite1", "features": ["openClose"]},
+                {"id": "55305", "type": "partial", "features": ["openClose"]},
+                {
+                    "id": "2",
+                    "type": "favorite1",
+                    "features": ["openClose", "tiltPosition"],
+                },
+            ]
+        )
+
+        assert {
+            alias_type: alias.id
+            for alias_type, alias in device.get_most_featured_aliases().items()
+        } == {"favorite1": "2", "partial": "55305"}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1685,7 +1685,7 @@ class TestSupportedAliases:
         ]
 
     def test_normalizes_integer_ids_to_string(self):
-        """The API is inconsistent about id typing, so ids are always strings."""
+        """Ids are exposed as strings, since goToAlias takes a string parameter."""
         device = self._device_with_aliases([{"id": 1, "type": "favorite1"}])
 
         alias = device.get_supported_aliases()[0]


### PR DESCRIPTION
Closes #2224.

`core:SupportedAliases` is currently exposed as a raw, untyped list, so every consumer has to walk the attribute themselves — and, as #2224 describes, most will treat it as "one entry per type" and get duplicate behavior. A Somfy `ogp:VenetianBlind` reports up to six `favorite1` slots for what is functionally a single "My position" preset.

## What this adds

```python
@define(kw_only=True)
class SupportedAlias:
    id: str
    type: str
    features: list[str] = field(factory=list)
```

Two `Device` methods:

- `get_supported_aliases() -> list[SupportedAlias]` — the slots exactly as reported, empty when the attribute is absent or not a list.
- `get_most_featured_aliases() -> dict[str, SupportedAlias]` — one alias per type, picking the id with the most `features`, ties broken by array order (first wins). This is the "simpler and sufficient" variant sketched at the end of #2224; the value is ready to pass straight to `goToAlias`.

## Deliberately left out

- **The `required_features` capability tiers** (step 3 of the app's algorithm in #2224). Consumers that show one control per type — which is what the app does — already land on the most capable id via the most-featured pick, so the tiers add an API surface nobody currently needs. Easy to add later without breaking this signature.
- **An `OverkizAliasType` enum.** `type` stays `str` so unknown types survive parsing instead of being dropped. Home Assistant relies on this to log a warning and fall back to a generated name when it meets a type it has no translation for; dropping unknown entries would hide new alias types instead of surfacing them.

Naming note: #2224 floated `get_most_featured_alias_by_type`; I went with `get_most_featured_aliases` since the `dict[str, ...]` return already says "by type". Happy to rename.

`id` is normalized with `str()` because `goToAlias` is declared as taking a single `STRING` parameter on every server in `docs/data`, and attrs does not enforce the annotation. Every payload observed in `docs/data` and in the Home Assistant fixtures already reports ids as strings.

## Tests

Six tests in `tests/test_models.py::TestSupportedAliases` covering the absent attribute, parsing, id normalization, most-featured resolution, array-order tie-breaking, and that one alias is kept per type. `tests/test_models.py` passes (184 tests).

Also documented under "Resolve supported aliases" in `docs/device-control.md`.

## Downstream

home-assistant/core#175567 consumes this: it replaces hand-rolled dict-walking with `get_most_featured_aliases()`, which collapses the six duplicate "My position" buttons on the venetian blind in HA's own fixtures down to one.