### PR TITLE
ci: Fix automatic labeling for fork pull requests

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  # Fork PRs need a base-repository token to apply labels.
+  pull_request_target:
     types: [opened, reopened, synchronize, edited]
 
 permissions:
@@ -26,8 +27,9 @@ jobs:
   # Apply Conventional-Commit labels from the PR title (PRs only).
   # The autolabeler is a separate sub-action; the main action above only drafts
   # releases and does not apply labels.
+  # Keep this privileged job free of PR code checkout or execution.
   autolabel:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Fork pull requests currently fail the Release Drafter autolabel check with `Resource not accessible by integration`: GitHub downgrades the `pull_request` token to read-only, preventing the action from applying labels (as seen in #2233).

Use `pull_request_target` and update the autolabel job condition so fork PRs can receive Conventional Commit labels. The job retains only `contents: read` and `pull-requests: write`, uses the existing SHA-pinned action, and does not check out or execute contributor code. Release drafting remains restricted to pushes to main.

Validation: all pre-commit checks passed, including actionlint, mypy, and ty; 556 tests passed. Pytest printed an unclosed client session message at shutdown. Live fork-event validation requires this workflow change to reach main, followed by a new PR event.
